### PR TITLE
Add babel env for jest

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -23,9 +23,21 @@ module.exports = {
           },
         ],
       ]
+    },
+    test: {
+      presets: [
+        [
+          '@babel/preset-env',
+          {
+            targets: {
+              node: 'current'
+            }
+          }
+        ]
+      ]
     }
   },
-  
+
   plugins: [
     '@babel/plugin-proposal-class-properties'
   ]


### PR DESCRIPTION
While trying to add CI I noticed that tests are currently failing because [Jest sets the `process.env.NODE_ENV` to `test`](https://jestjs.io/docs/en/getting-started#using-babel) which we do not have in babel config. This PR adds an `env` for test.

