### PR TITLE
Inject correct attribution into vector tile sources

### DIFF
--- a/src/tms_service.js
+++ b/src/tms_service.js
@@ -47,9 +47,12 @@ export class TMSService {
         const url = this._proxyPath + tileUrl;
         return this._emsClient.extendUrlWithParams(url);
       });
+
+      const htmlAttribution = await this.getHTMLAttribution()
       inlinedSources[sourceName] = {
         type: 'vector',
         ...sourceJson,
+        attribution: htmlAttribution,
         tiles: extendedTileUrls
       };
     }

--- a/src/tms_service.js
+++ b/src/tms_service.js
@@ -47,7 +47,7 @@ export class TMSService {
         const url = this._proxyPath + tileUrl;
         return this._emsClient.extendUrlWithParams(url);
       });
-
+      // Override the attribution in the sources with the localized attribution
       const htmlAttribution = await this.getHTMLAttribution()
       inlinedSources[sourceName] = {
         type: 'vector',


### PR DESCRIPTION
This fixes the handling of vector tile sources from EMS by injecting the attributions from the root manifest. 