### PR TITLE
Add appName and appVersion parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Yarn
 import { EMSClient } from '@elastic/ems-client';
 
 const emsClient = new EMSClient({
-  kbnVersion: '7.6.0',
+  appVersion: '7.6.0',
+  appName: 'kibana',
   tileApiUrl: 'https://tiles.maps.elastic.co',
   fileApiUrl: 'https://vector.maps.elastic.co',
   emsVersion: '7.6',

--- a/src/ems_client.js
+++ b/src/ems_client.js
@@ -93,6 +93,8 @@ export class EMSClient {
 
   constructor({
     kbnVersion,
+    appVersion,
+    appName,
     manifestServiceUrl,
     tileApiUrl,
     fileApiUrl,
@@ -104,11 +106,16 @@ export class EMSClient {
     proxyPath,
   }) {
 
+    // Remove kbnVersion in 8.0
+    if (kbnVersion) {
+      console.warn('The "kbnVersion" parameter for ems-client is deprecated. Please use "appVersion" instead.');
+      appVersion = appVersion || kbnVersion;
+    }
 
     this._queryParams = {
       elastic_tile_service_tos: 'agree',
-      my_app_name: 'kibana',
-      my_app_version: kbnVersion,
+      my_app_name: appName || 'kibana',
+      my_app_version: appVersion,
     };
 
     this._sanitizer = htmlSanitizer ? htmlSanitizer : x => x;

--- a/test/ems_client.test.js
+++ b/test/ems_client.test.js
@@ -36,7 +36,7 @@ describe('ems_client', () => {
     expect(tiles.length).toBe(3);
 
     const tileService = tiles[0];
-    expect(await tileService.getUrlTemplate()).toBe('https://tiles.foobar/raster/styles/osm-bright/{z}/{x}/{y}.png?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version=7.x.x');
+    expect(await tileService.getUrlTemplate()).toBe('https://tiles.foobar/raster/styles/osm-bright/{z}/{x}/{y}.png?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x');
 
     expect (tileService.getHTMLAttribution()).toBe('<a rel="noreferrer noopener" href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a> | <a rel="noreferrer noopener" href="https://openmaptiles.org">OpenMapTiles</a> | <a rel="noreferrer noopener" href="https://www.maptiler.com">MapTiler</a> | <a rel="noreferrer noopener" href="https://www.elastic.co/elastic-maps-service">Elastic Maps Service</a>');
     expect (await tileService.getMinZoom()).toBe(0);
@@ -57,7 +57,7 @@ describe('ems_client', () => {
     expect(tiles.length).toBe(3);
 
     const tileService = tiles[0];
-    expect(await tileService.getUrlTemplate()).toBe('https://tiles.foobar/raster/styles/osm-bright/{z}/{x}/{y}.png?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version=7.x.x');
+    expect(await tileService.getUrlTemplate()).toBe('https://tiles.foobar/raster/styles/osm-bright/{z}/{x}/{y}.png?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x');
 
     expect (tileService.getHTMLAttribution()).toBe('<a rel="noreferrer noopener" href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a> | <a rel="noreferrer noopener" href="https://openmaptiles.org">OpenMapTiles</a> | <a rel="noreferrer noopener" href="https://www.maptiler.com">MapTiler</a> | <a rel="noreferrer noopener" href="https://www.elastic.co/elastic-maps-service">Elastic Maps Service</a>');
     expect (await tileService.getMinZoom()).toBe(0);
@@ -76,14 +76,14 @@ describe('ems_client', () => {
 
     const tilesBefore = await emsClient.getTMSServices();
     const urlBefore = await tilesBefore[0].getUrlTemplate();
-    expect(urlBefore).toBe('https://tiles.foobar/raster/styles/osm-bright/{z}/{x}/{y}.png?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version=7.x.x');
+    expect(urlBefore).toBe('https://tiles.foobar/raster/styles/osm-bright/{z}/{x}/{y}.png?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x');
 
     emsClient.addQueryParams({
       'foo': 'bar'
     });
     let tiles = await emsClient.getTMSServices();
     let url = await tiles[0].getUrlTemplate();
-    expect(url).toBe('https://tiles.foobar/raster/styles/osm-bright/{z}/{x}/{y}.png?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version=7.x.x&foo=bar');
+    expect(url).toBe('https://tiles.foobar/raster/styles/osm-bright/{z}/{x}/{y}.png?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x&foo=bar');
 
     emsClient.addQueryParams({
       'foo': 'schmoo',
@@ -91,7 +91,7 @@ describe('ems_client', () => {
     });
     tiles = await emsClient.getTMSServices();
     url = await tiles[0].getUrlTemplate();
-    expect(url).toBe('https://tiles.foobar/raster/styles/osm-bright/{z}/{x}/{y}.png?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version=7.x.x&foo=schmoo&bar=foo');
+    expect(url).toBe('https://tiles.foobar/raster/styles/osm-bright/{z}/{x}/{y}.png?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x&foo=schmoo&bar=foo');
 
 
   });
@@ -159,7 +159,7 @@ describe('ems_client', () => {
     { name: 'name', description: 'nom', type: 'property' } ]);
 
     expect(layer.getDefaultFormatType()).toBe('geojson');
-    expect(layer.getDefaultFormatUrl()).toBe('https://files.foobar/files/world_countries_v1.geo.json?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version=7.x.x&foo=bar');
+    expect(layer.getDefaultFormatUrl()).toBe('https://files.foobar/files/world_countries_v1.geo.json?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x&foo=bar');
 
 
   });
@@ -237,12 +237,12 @@ describe('ems_client', () => {
       return EMS_STYLE_BRIGHT_PROXIED;
     };
     const urlTemplate = await tmsServices[0].getUrlTemplate();
-    expect(urlTemplate).toBe('http://proxy.com/foobar/tiles/raster/osm_bright/{x}/{y}/{z}.jpg?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version=7.x.x');
+    expect(urlTemplate).toBe('http://proxy.com/foobar/tiles/raster/osm_bright/{x}/{y}/{z}.jpg?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x');
 
     const fileLayers = await emsClient.getFileLayers();
     expect(fileLayers.length).toBe(1);
     const fileLayer = fileLayers[0];
-    expect(fileLayer.getDefaultFormatUrl()).toBe('http://proxy.com/foobar/vector/files/world_countries.json?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version=7.x.x');
+    expect(fileLayer.getDefaultFormatUrl()).toBe('http://proxy.com/foobar/vector/files/world_countries.json?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x');
 
   });
 
@@ -263,7 +263,7 @@ describe('ems_client', () => {
     expect(styleSheet.layers.length).toBe(111);
     expect(styleSheet.sprite).toBe('https://tiles.foobar/styles/osm-bright/sprite');
     expect(styleSheet.sources.openmaptiles.tiles.length).toBe(1);
-    expect(styleSheet.sources.openmaptiles.tiles[0]).toBe('https://tiles.foobar/data/v3/{z}/{x}/{y}.pbf?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version=7.x.x');
+    expect(styleSheet.sources.openmaptiles.tiles[0]).toBe('https://tiles.foobar/data/v3/{z}/{x}/{y}.pbf?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x');
 
   });
 
@@ -288,7 +288,7 @@ describe('ems_client', () => {
     expect(styleSheet.layers.length).toBe(111);
     expect(styleSheet.sprite).toBe('http://proxy.com/foobar/tiles/styles/osm-bright/sprite');
     expect(styleSheet.sources.openmaptiles.tiles.length).toBe(1);
-    expect(styleSheet.sources.openmaptiles.tiles[0]).toBe('http://proxy.com/foobar/tiles/data/v3/{z}/{x}/{y}.pbf?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version=7.x.x');
+    expect(styleSheet.sources.openmaptiles.tiles[0]).toBe('http://proxy.com/foobar/tiles/data/v3/{z}/{x}/{y}.pbf?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x');
 
   });
 

--- a/test/ems_client_util.js
+++ b/test/ems_client_util.js
@@ -39,7 +39,8 @@ export function getEMSClient(options = {}) {
 
   const emsClient = new EMSClient({
     language: 'en',
-    kbnVersion: '7.x.x',
+    appVersion: '7.x.x',
+    appName: 'tester',
     htmlSanitizer: x => x,
     landingPageUrl: 'https://landing.foobar',
     ...options


### PR DESCRIPTION
Fixes #17. 

This PR adds an `appName` parameter to the constructor which updates the `my_app_name` parameter in the query string in requests to EMS. Previously, `my_app_name` was hardcoded to "kibana", but we should support additional clients such as ems-landing-page. `appName` defaults to "kibana" if not specified.

This PR also adds a `appVersion` parameter designed to replace the `kbnVersion` parameter in the constructor since `kbnVersion` is a bit of a misnomer since ems-client supports additional clients besides Kibana. A deprecation warning is logged if `kbnVersion` is specified. Both `appVersion` and `kbnVersion` apply the `my_app_version` query string parameter in requests to EMS. If not specified, `appVersion` falls back to the `kbnVersion` parameter.