### PR TITLE
Correctly format manifest URLs when api URLs contain trailing slashes

### DIFF
--- a/src/ems_client.js
+++ b/src/ems_client.js
@@ -22,6 +22,7 @@ import { TMSService } from './tms_service';
 import { FileLayer } from './file_layer';
 import semver from 'semver';
 import { format as formatUrl, parse as parseUrl } from 'url';
+import { toAbsoluteUrl } from './utils';
 
 const DEFAULT_EMS_VERSION = '7.8';
 
@@ -110,7 +111,7 @@ export class EMSClient {
       console.warn('The "kbnVersion" parameter for ems-client is deprecated. Please use "appVersion" instead.');
       appVersion = appVersion || kbnVersion;
     }
-    
+
     if (!fetchFunction || typeof fetchFunction !== 'function') {
       throw('No `fetchFunction` provided. This argument is required.');
     }
@@ -235,13 +236,13 @@ export class EMSClient {
         if (this._tileApiUrl) {
           services.push({
             type: 'tms',
-            manifest: `${this._tileApiUrl}/${this._emsVersion}/manifest`,
+            manifest: toAbsoluteUrl(this._tileApiUrl,`${this._emsVersion}/manifest`),
           });
         }
         if (this._fileApiUrl) {
           services.push({
             type: 'file',
-            manifest: `${this._fileApiUrl}/${this._emsVersion}/manifest`,
+            manifest: toAbsoluteUrl(this._fileApiUrl,`${this._emsVersion}/manifest`),
           });
         }
         return { services: services };

--- a/test/ems_client.test.js
+++ b/test/ems_client.test.js
@@ -23,6 +23,35 @@ import EMS_STYLE_BRIGHT_VECTOR_PROXIED  from './ems_mocks/sample_style_bright_ve
 
 describe('ems_client', () => {
 
+  it('should get api manifests', async () => {
+    const emsClient = getEMSClient({
+      language: 'zz',
+      tileApiUrl: 'https://tiles.foobar',
+      fileApiUrl: 'https://files.foobar',
+      emsVersion: '7.6',
+    });
+    const spy = jest.spyOn(emsClient, 'getManifest');
+    await emsClient.getTMSServices();
+    await emsClient.getFileLayers();
+
+    expect(spy).toHaveBeenNthCalledWith(1, 'https://tiles.foobar/v7.6/manifest');
+    expect(spy).toHaveBeenNthCalledWith(2, 'https://files.foobar/v7.6/manifest');
+  });
+
+  it('should handle handle end slashes in api urls correctly', async () => {
+    const emsClient = getEMSClient({
+      language: 'zz',
+      tileApiUrl: 'https://tiles.foobar/',
+      fileApiUrl: 'https://files.foobar/',
+      emsVersion: '7.6',
+    });
+    const spy = jest.spyOn(emsClient, 'getManifest');
+    await emsClient.getTMSServices();
+    await emsClient.getFileLayers();
+
+    expect(spy).toHaveBeenNthCalledWith(1, 'https://tiles.foobar/v7.6/manifest');
+    expect(spy).toHaveBeenNthCalledWith(2, 'https://files.foobar/v7.6/manifest');
+  });
 
   it('should get the tile service', async () => {
 

--- a/test/ems_client.test.js
+++ b/test/ems_client.test.js
@@ -38,7 +38,7 @@ describe('ems_client', () => {
     expect(spy).toHaveBeenNthCalledWith(2, 'https://files.foobar/v7.6/manifest');
   });
 
-  it('should handle handle end slashes in api urls correctly', async () => {
+  it('should handle end slashes in api urls correctly', async () => {
     const emsClient = getEMSClient({
       language: 'zz',
       tileApiUrl: 'https://tiles.foobar/',
@@ -323,4 +323,3 @@ describe('ems_client', () => {
 
 
 });
-


### PR DESCRIPTION
This fixes a bug where URLs for tile and file manifests may be deformed when the `fileApiUrl` or `tileApiUrl` contain trailing slashes.

Also added a test to check for this in the future. 😅 

This is required to implement https://github.com/elastic/ems-landing-page/issues/168.