### PR TITLE
Bump to 7.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [7.9.0] - 2020-05-29
+### Changed
+- Convert source code to Typescript
+- Added better linting with eslint and prettier
+
+
 ## [7.8.1] - 2020-04-06
 ### Fixed
 - Correctly handle API urls that end in slashes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/ems-client",
-  "version": "7.8.0",
+  "version": "7.9.0",
   "description": "JavaScript client library for the Elastic Maps Service",
   "main": "target/node/index.js",
   "browser": "target/web/index.js",

--- a/src/ems_client.ts
+++ b/src/ems_client.ts
@@ -25,7 +25,7 @@ import { format as formatUrl, parse as parseUrl, UrlObject } from 'url';
 import { toAbsoluteUrl } from './utils';
 import { ParsedUrlQueryInput } from 'querystring';
 
-const DEFAULT_EMS_VERSION = '7.8';
+const DEFAULT_EMS_VERSION = '7.9';
 
 type URLMeaningfulParts = {
   auth?: string | null;


### PR DESCRIPTION
This PR will update to EMS v7.9 and get ready to publish 7.9.0 to NPM.

Fixes #29 