### PR TITLE
[7.x] Fix regression for missing source type (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [7.9.1] - 2020-06-01
+### Fixed
+- Fixed regression of missing source type on vector tile styles
+
 ## [7.9.0] - 2020-05-29
 ### Changed
 - Convert source code to Typescript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/ems-client",
-  "version": "7.9.0",
+  "version": "7.9.1",
   "description": "JavaScript client library for the Elastic Maps Service",
   "main": "target/node/index.js",
   "browser": "target/web/index.js",

--- a/src/tms_service.ts
+++ b/src/tms_service.ts
@@ -114,6 +114,7 @@ export class TMSService extends AbstractEmsService {
           const htmlAttribution = await this.getHTMLAttribution();
           inlinedSources[sourceName] = {
             ...sourceJson,
+            type: 'vector',
             attribution: htmlAttribution,
             tiles: extendedTileUrls,
           };

--- a/test/ems_client.test.ts
+++ b/test/ems_client.test.ts
@@ -288,6 +288,7 @@ describe('ems_client', () => {
     expect(styleSheet!.sources!.openmaptiles!.tiles[0]).toBe(
       'https://tiles.foobar/data/v3/{z}/{x}/{y}.pbf?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x'
     );
+    expect(styleSheet!.sources!.openmaptiles!.type).toBe('vector');
   });
 
   it('should retrieve vectorstylesheet with all sources inlined) (proxy)', async () => {
@@ -309,5 +310,6 @@ describe('ems_client', () => {
     expect(styleSheet!.sources!.openmaptiles!.tiles![0]).toBe(
       'http://proxy.com/foobar/tiles/data/v3/{z}/{x}/{y}.pbf?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x'
     );
+    expect(styleSheet!.sources!.openmaptiles!.type).toBe('vector');
   });
 });


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix regression for missing source type (#33)