### PR TITLE
Export FileLayer and TMSService

### DIFF
--- a/src/file_layer.ts
+++ b/src/file_layer.ts
@@ -34,8 +34,12 @@ export class FileLayer extends AbstractEmsService {
     this._config = config;
   }
 
+  getFields(): FileLayerConfig['fields'] {
+    return this._config.fields;
+  }
+
   getFieldsInLanguage(): { type: string; name: string; description: string }[] {
-    return this._config.fields.map((field) => {
+    return this.getFields().map((field) => {
       return {
         type: field.type,
         name: field.id,

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,3 +19,5 @@
 
 export { EMSClient } from './ems_client';
 export { ORIGIN } from './origin';
+export { FileLayer } from './file_layer';
+export { TMSService } from './tms_service';

--- a/test/ems_client.test.ts
+++ b/test/ems_client.test.ts
@@ -151,6 +151,29 @@ describe('ems_client', () => {
     const layer = layers[0];
     expect(layer.getId()).toBe('world_countries');
     expect(layer.hasId('world_countries')).toBe(true);
+    expect(layer.getFields()).toMatchObject([
+      {
+        type: 'id',
+        id: 'iso2',
+        label: {
+          en: 'ISO 3166-1 alpha-2 code',
+        },
+      },
+      {
+        type: 'id',
+        id: 'iso3',
+        label: {
+          en: 'ISO 3166-1 alpha-3 code',
+        },
+      },
+      {
+        type: 'property',
+        id: 'name',
+        label: {
+          en: 'name',
+        },
+      },
+    ]);
 
     expect(layer.getHTMLAttribution()).toBe(
       '<a rel="noreferrer noopener" href="http://www.naturalearthdata.com/about/terms-of-use">Made with NaturalEarth</a> | <a rel="noreferrer noopener" href="https://www.elastic.co/elastic-maps-service">Elastic Maps Service</a>'


### PR DESCRIPTION
We need to expose the FileLayer and TMSService types for Kibana.

This also exposes a `getFields` method for FileLayer.