### PR TITLE
[7.9] Remove @types/mapbox-gl  (#39)

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@babel/preset-typescript": "^7.9.0",
     "@types/jest": "^25.2.1",
     "@types/lodash": "^4.14.150",
-    "@types/mapbox-gl": "^1.9.1",
     "@types/node": "^13.13.5",
     "@types/node-fetch": "^2.5.7",
     "@types/semver": "^7.1.0",

--- a/src/tms_service.ts
+++ b/src/tms_service.ts
@@ -20,21 +20,36 @@
 import _ from 'lodash';
 import { EMSClient, EmsTmsFormat, TMSServiceConfig } from './ems_client';
 import { AbstractEmsService } from './ems_service';
-import { Sources, Style, VectorSource } from 'mapbox-gl';
 
-type EmsVectorSource = VectorSource & {
+type EmsVectorSource = {
+  type: 'vector';
   url: string;
   tiles: string[];
+  bounds?: number[];
+  scheme?: 'xyz' | 'tms';
+  minzoom?: number;
+  maxzoom?: number;
+  attribution?: string;
 };
 
-type EmsVectorSources = Sources & {
+type EmsVectorSources = {
   [sourceName: string]: EmsVectorSource;
 };
 
-type EmsVectorStyle = Style & {
+type EmsVectorStyle = {
   sources: EmsVectorSources;
   sprite: string;
   glyphs: string;
+  bearing?: number;
+  center?: number[];
+  layers?: unknown[];
+  metadata?: unknown;
+  name?: string;
+  pitch?: number;
+  light?: unknown;
+  transition?: unknown;
+  version: number;
+  zoom?: number;
 };
 
 type EmsSprite = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1221,11 +1221,6 @@
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
-"@types/geojson@*":
-  version "7946.0.7"
-  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.7.tgz#c8fa532b60a0042219cdf173ca21a975ef0666ad"
-  integrity sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==
-
 "@types/graceful-fs@^4.1.2":
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.3.tgz#039af35fe26bec35003e8d86d2ee9c586354348f"
@@ -1275,13 +1270,6 @@
   version "4.14.150"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.150.tgz#649fe44684c3f1fcb6164d943c5a61977e8cf0bd"
   integrity sha512-kMNLM5JBcasgYscD9x/Gvr6lTAv2NVgsKtet/hm93qMyf/D1pt+7jeEZklKJKxMVmXjxbRVQQGfqDSfipYCO6w==
-
-"@types/mapbox-gl@^1.9.1":
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/@types/mapbox-gl/-/mapbox-gl-1.9.1.tgz#78b62f8a1ead78bc525a4c1db84bb71fa0fcc579"
-  integrity sha512-5LS/fljbGjCPfjtOK5+pz8TT0PL4bBXTnN/PDbPtTQMqQdY/KWTWE4jRPuo0fL5wctd543DCptEUTydn+JK+gA==
-  dependencies:
-    "@types/geojson" "*"
 
 "@types/node-fetch@^2.5.7":
   version "2.5.7"


### PR DESCRIPTION
Backports the following commits to 7.9:
 - Remove @types/mapbox-gl  (#39)