### PR TITLE
[7.9] Remove html-generation method (#46)

### DIFF
--- a/src/ems_service.ts
+++ b/src/ems_service.ts
@@ -23,7 +23,6 @@ import { toAbsoluteUrl } from './utils';
 
 export interface IEmsService {
   getAttributions(): { url: string; label: string }[];
-  getHTMLAttribution(): string;
   getMarkdownAttribution(): string;
   getDisplayName(): string;
   getId(): string;
@@ -52,16 +51,6 @@ export abstract class AbstractEmsService implements IEmsService {
         label: label,
       };
     });
-  }
-
-  getHTMLAttribution(): string {
-    const attributions = this._config.attribution.map((attribution) => {
-      const url = this._emsClient.getValueInLanguage(attribution.url);
-      const label = this._emsClient.getValueInLanguage(attribution.label);
-      const html = url ? `<a rel="noreferrer noopener" href="${url}">${label}</a>` : label;
-      return this._emsClient.sanitizeHtml(html);
-    });
-    return attributions.join(' | '); //!!!this is the current convention used in Kibana
   }
 
   getMarkdownAttribution(): string {

--- a/src/tms_service.ts
+++ b/src/tms_service.ts
@@ -125,11 +125,9 @@ export class TMSService extends AbstractEmsService {
             const url = this._proxyPath + this._getAbsoluteUrl(tileUrl);
             return this._emsClient.extendUrlWithParams(url);
           });
-          // Override the attribution in the sources with the localized attribution
-          const htmlAttribution = await this.getHTMLAttribution();
           inlinedSources[sourceName] = {
             ...sourceJson,
-            attribution: htmlAttribution,
+            type: 'vector',
             tiles: extendedTileUrls,
           };
         }

--- a/test/ems_client.test.ts
+++ b/test/ems_client.test.ts
@@ -65,9 +65,6 @@ describe('ems_client', () => {
       'https://tiles.foobar/raster/styles/osm-bright/{z}/{x}/{y}.png?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x'
     );
 
-    expect(tileService.getHTMLAttribution()).toBe(
-      '<a rel="noreferrer noopener" href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a> | <a rel="noreferrer noopener" href="https://openmaptiles.org">OpenMapTiles</a> | <a rel="noreferrer noopener" href="https://www.maptiler.com">MapTiler</a> | <a rel="noreferrer noopener" href="https://www.elastic.co/elastic-maps-service">Elastic Maps Service</a>'
-    );
     expect(await tileService.getMinZoom()).toBe(0);
     expect(await tileService.getMaxZoom()).toBe(10);
     expect(tileService.hasId('road_map')).toBe(true);
@@ -89,9 +86,6 @@ describe('ems_client', () => {
       'https://tiles.foobar/raster/styles/osm-bright/{z}/{x}/{y}.png?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x'
     );
 
-    expect(tileService.getHTMLAttribution()).toBe(
-      '<a rel="noreferrer noopener" href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a> | <a rel="noreferrer noopener" href="https://openmaptiles.org">OpenMapTiles</a> | <a rel="noreferrer noopener" href="https://www.maptiler.com">MapTiler</a> | <a rel="noreferrer noopener" href="https://www.elastic.co/elastic-maps-service">Elastic Maps Service</a>'
-    );
     expect(await tileService.getMinZoom()).toBe(0);
     expect(await tileService.getMaxZoom()).toBe(10);
     expect(tileService.hasId('road_map')).toBe(true);
@@ -175,10 +169,6 @@ describe('ems_client', () => {
       },
     ]);
 
-    expect(layer.getHTMLAttribution()).toBe(
-      '<a rel="noreferrer noopener" href="http://www.naturalearthdata.com/about/terms-of-use">Made with NaturalEarth</a> | <a rel="noreferrer noopener" href="https://www.elastic.co/elastic-maps-service">Elastic Maps Service</a>'
-    );
-
     expect(layer.getDisplayName()).toBe('World Countries');
   });
 
@@ -197,10 +187,6 @@ describe('ems_client', () => {
     const layer = layers[0];
     expect(layer.getId()).toBe('world_countries');
     expect(layer.hasId('world_countries')).toBe(true);
-
-    expect(layer.getHTMLAttribution()).toBe(
-      '<a rel="noreferrer noopener" href="http://www.naturalearthdata.com/about/terms-of-use">Made with NaturalEarth</a> | <a rel="noreferrer noopener" href="https://www.elastic.co/elastic-maps-service">Elastic Maps Service</a>'
-    );
     expect(layer.getDisplayName()).toBe('pays');
 
     const fields = layer.getFieldsInLanguage();
@@ -228,10 +214,6 @@ describe('ems_client', () => {
     const layer = layers[0];
     expect(layer.getId()).toBe('world_countries');
     expect(layer.hasId('world_countries')).toBe(true);
-
-    expect(layer.getHTMLAttribution()).toBe(
-      '<a rel="noreferrer noopener" href="http://www.naturalearthdata.com/about/terms-of-use">Made with NaturalEarth</a> | <a rel="noreferrer noopener" href="https://www.elastic.co/elastic-maps-service">Elastic Maps Service</a>'
-    );
     expect(layer.getDisplayName()).toBe('World Countries');
 
     const fields = layer.getFieldsInLanguage();


### PR DESCRIPTION
Backports the following commits to 7.9:
 - Remove html-generation method (#46)