### PR TITLE
Add functions to get specific file formats

### DIFF
--- a/src/ems_client.ts
+++ b/src/ems_client.ts
@@ -19,7 +19,7 @@
 
 import _ from 'lodash';
 import { TMSService } from './tms_service';
-import { FileLayer } from './file_layer';
+import { EMSFormatType, FileLayer } from './file_layer';
 import semver from 'semver';
 import { format as formatUrl, parse as parseUrl, UrlObject } from 'url';
 import { toAbsoluteUrl } from './utils';
@@ -179,13 +179,13 @@ export type EmsLayerAttribution = {
 };
 
 export type EmsFileLayerFormatGeoJson = {
-  type: 'geojson';
+  type: EMSFormatType.geojson;
   url: string;
   legacy_default: boolean;
 };
 
 export type EmsFileLayerFormatTopoJson = {
-  type: 'topojson';
+  type: EMSFormatType.topojson;
   url: string;
   legacy_default: boolean;
   meta: {

--- a/src/file_layer.ts
+++ b/src/file_layer.ts
@@ -26,6 +26,14 @@ import {
 } from './ems_client';
 import { AbstractEmsService } from './ems_service';
 
+export enum EMSFormatType {
+  geojson = 'geojson',
+  topojson = 'topojson',
+}
+export type EMSFormatTypeStrings = keyof typeof EMSFormatType;
+
+type EMSFormats = EmsFileLayerFormatGeoJson | EmsFileLayerFormatTopoJson;
+
 export class FileLayer extends AbstractEmsService {
   protected readonly _config: FileLayerConfig;
 
@@ -78,19 +86,29 @@ export class FileLayer extends AbstractEmsService {
     return format.type;
   }
 
+  getFormatOfType(type: EMSFormatTypeStrings): EMSFormatTypeStrings {
+    const format = this._getFormatOfType(type);
+    return format.type;
+  }
+
   getDefaultFormatMeta(): { [key: string]: string } | undefined {
     const format = this._getDefaultFormat();
-    if ('meta' in format) {
-      return format.meta;
-    } else {
-      return;
-    }
+    return this._getFormatMeta(format);
+  }
+
+  getFormatOfTypeMeta(type: EMSFormatTypeStrings): { [key: string]: string } | undefined {
+    const format = this._getFormatOfType(type);
+    return this._getFormatMeta(format);
   }
 
   getDefaultFormatUrl(): string {
     const format = this._getDefaultFormat();
-    const url = this._proxyPath + this._getAbsoluteUrl(format.url);
-    return this._emsClient.extendUrlWithParams(url);
+    return this._getFormatUrl(format);
+  }
+
+  getFormatOfTypeUrl(type: EMSFormatTypeStrings) {
+    const format = this._getFormatOfType(type);
+    return this._getFormatUrl(format);
   }
 
   getCreatedAt(): string {
@@ -101,7 +119,20 @@ export class FileLayer extends AbstractEmsService {
     return this._emsClient.getFileApiUrl();
   }
 
-  private _getDefaultFormat(): EmsFileLayerFormatGeoJson | EmsFileLayerFormatTopoJson {
+  private _getFormatUrl(format: EMSFormats) {
+    const url = this._proxyPath + this._getAbsoluteUrl(format.url);
+    return this._emsClient.extendUrlWithParams(url);
+  }
+
+  private _getFormatMeta(format: EMSFormats) {
+    if ('meta' in format) {
+      return format.meta;
+    } else {
+      return;
+    }
+  }
+
+  private _getDefaultFormat(): EMSFormats {
     const defaultFormat = this._config.formats.find((format) => {
       return format.legacy_default;
     });
@@ -109,5 +140,15 @@ export class FileLayer extends AbstractEmsService {
       return defaultFormat;
     }
     return this._config.formats[0];
+  }
+
+  private _getFormatOfType(type: EMSFormatTypeStrings): EMSFormats {
+    const requestedFormat = this._config.formats.find((format) => {
+      return format.type === type;
+    });
+    if (!requestedFormat) {
+      return this._getDefaultFormat();
+    }
+    return requestedFormat;
   }
 }

--- a/src/file_layer.ts
+++ b/src/file_layer.ts
@@ -146,9 +146,6 @@ export class FileLayer extends AbstractEmsService {
     const requestedFormat = this._config.formats.find((format) => {
       return format.type === type;
     });
-    if (!requestedFormat) {
-      return this._getDefaultFormat();
-    }
-    return requestedFormat;
+    return requestedFormat || this._getDefaultFormat();
   }
 }

--- a/test/ems_client.test.ts
+++ b/test/ems_client.test.ts
@@ -170,6 +170,14 @@ describe('ems_client', () => {
     ]);
 
     expect(layer.getDisplayName()).toBe('World Countries');
+    expect(layer.getFormatOfTypeUrl('geojson')).toBe(
+      'https://files.foobar/files/world_countries_v1.geo.json?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x'
+    );
+    expect(layer.getFormatOfType('geojson')).toBe('geojson');
+    expect(layer.getFormatOfTypeMeta('geojson')).toBeUndefined();
+    expect(layer.getFormatOfTypeMeta('topojson')).toStrictEqual({
+      feature_collection_path: 'data',
+    });
   });
 
   it('.getFileLayers[0] - localized (known)', async () => {
@@ -196,10 +204,11 @@ describe('ems_client', () => {
       { name: 'name', description: 'nom', type: 'property' },
     ]);
 
-    expect(layer.getDefaultFormatType()).toBe('geojson');
+    expect(layer.getDefaultFormatType()).toBe('topojson');
     expect(layer.getDefaultFormatUrl()).toBe(
-      'https://files.foobar/files/world_countries_v1.geo.json?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x&foo=bar'
+      'https://files.foobar/files/world_countries_v7.topo.json?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x&foo=bar'
     );
+    expect(layer.getDefaultFormatMeta()).toStrictEqual({ feature_collection_path: 'data' });
   });
 
   it('.getFileLayers[0] - localized (fallback)', async () => {
@@ -270,7 +279,10 @@ describe('ems_client', () => {
     expect(fileLayers.length).toBe(1);
     const fileLayer = fileLayers[0];
     expect(fileLayer.getDefaultFormatUrl()).toBe(
-      'http://proxy.com/foobar/vector/files/world_countries.json?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x'
+      'http://proxy.com/foobar/vector/files/world_countries_v7.topo.json?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x'
+    );
+    expect(fileLayer.getFormatOfTypeUrl('geojson')).toBe(
+      'http://proxy.com/foobar/vector/files/world_countries_v1.geo.json?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x'
     );
   });
 

--- a/test/ems_client.test.ts
+++ b/test/ems_client.test.ts
@@ -131,10 +131,10 @@ describe('ems_client', () => {
       emsVersion: '7.6',
     });
     const layers = await emsClient.getFileLayers();
-    expect(layers.length).toBe(18);
+    expect(layers.length).toBe(19);
   });
 
-  it('.getFileLayers[0]', async () => {
+  it('.getFileLayers with a single format', async () => {
     const emsClient = getEMSClient({
       tileApiUrl: 'https://tiles.foobar',
       fileApiUrl: 'https://files.foobar',
@@ -174,8 +174,53 @@ describe('ems_client', () => {
       'https://files.foobar/files/world_countries_v1.geo.json?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x'
     );
     expect(layer.getFormatOfType('geojson')).toBe('geojson');
+    expect(layer.getDefaultFormatType()).toBe('geojson');
     expect(layer.getFormatOfTypeMeta('geojson')).toBeUndefined();
-    expect(layer.getFormatOfTypeMeta('topojson')).toStrictEqual({
+    expect(layer.getFormatOfTypeMeta('topojson')).toBeUndefined();
+  });
+
+  it('.getFileLayers with multiple formats', async () => {
+    const emsClient = getEMSClient({
+      tileApiUrl: 'https://tiles.foobar',
+      fileApiUrl: 'https://files.foobar',
+      emsVersion: '7.6',
+    });
+    const layers = await emsClient.getFileLayers();
+
+    const layer = layers[1];
+    expect(layer.getId()).toBe('administrative_regions_lvl2');
+    expect(layer.hasId('administrative_regions_lvl2')).toBe(true);
+    expect(layer.getFields()).toMatchObject([
+      {
+        type: 'id',
+        id: 'region_iso_code',
+        label: {
+          en: 'Region ISO code',
+        },
+      },
+      {
+        type: 'property',
+        id: 'region_name',
+        label: {
+          en: 'Region name',
+        },
+      },
+    ]);
+
+    expect(layer.getDisplayName()).toBe('Administrative regions');
+    expect(layer.getFormatOfTypeUrl('geojson')).toBe(
+      'https://files.foobar/files/admin_regions_lvl2_v2.geo.json?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x'
+    );
+    expect(layer.getFormatOfTypeUrl('topojson')).toBe(
+      'https://files.foobar/files/admin_regions_lvl2_v2.topo.json?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x'
+    );
+    expect(layer.getDefaultFormatUrl()).toBe(
+      'https://files.foobar/files/admin_regions_lvl2_v2.topo.json?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x'
+    );
+    expect(layer.getFormatOfType('geojson')).toBe('geojson');
+    expect(layer.getDefaultFormatType()).toBe('topojson');
+    expect(layer.getFormatOfTypeMeta('geojson')).toBeUndefined();
+    expect(layer.getFormatOfTypeMeta('topojson')).toMatchObject({
       feature_collection_path: 'data',
     });
   });
@@ -204,11 +249,11 @@ describe('ems_client', () => {
       { name: 'name', description: 'nom', type: 'property' },
     ]);
 
-    expect(layer.getDefaultFormatType()).toBe('topojson');
+    expect(layer.getDefaultFormatType()).toBe('geojson');
     expect(layer.getDefaultFormatUrl()).toBe(
-      'https://files.foobar/files/world_countries_v7.topo.json?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x&foo=bar'
+      'https://files.foobar/files/world_countries_v1.geo.json?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x&foo=bar'
     );
-    expect(layer.getDefaultFormatMeta()).toStrictEqual({ feature_collection_path: 'data' });
+    expect(layer.getDefaultFormatMeta()).toBeUndefined();
   });
 
   it('.getFileLayers[0] - localized (fallback)', async () => {
@@ -276,13 +321,13 @@ describe('ems_client', () => {
     );
 
     const fileLayers = await emsClient.getFileLayers();
-    expect(fileLayers.length).toBe(1);
+    expect(fileLayers.length).toBe(2);
     const fileLayer = fileLayers[0];
     expect(fileLayer.getDefaultFormatUrl()).toBe(
-      'http://proxy.com/foobar/vector/files/world_countries_v7.topo.json?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x'
+      'http://proxy.com/foobar/vector/files/world_countries.json?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x'
     );
     expect(fileLayer.getFormatOfTypeUrl('geojson')).toBe(
-      'http://proxy.com/foobar/vector/files/world_countries_v1.geo.json?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x'
+      'http://proxy.com/foobar/vector/files/world_countries.json?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x'
     );
   });
 

--- a/test/ems_mocks/sample_files.json
+++ b/test/ems_mocks/sample_files.json
@@ -24,8 +24,15 @@
       "formats": [
         {
           "type": "geojson",
-          "url": "/files/world_countries_v1.geo.json",
-          "legacy_default": true
+          "url": "/files/world_countries_v1.geo.json"
+        }, 
+        {
+          "type": "topojson",
+          "url": "/files/world_countries_v7.topo.json",
+          "legacy_default": true,
+          "meta": {
+            "feature_collection_path": "data"
+          }
         }
       ],
       "fields": [

--- a/test/ems_mocks/sample_files.json
+++ b/test/ems_mocks/sample_files.json
@@ -24,15 +24,8 @@
       "formats": [
         {
           "type": "geojson",
-          "url": "/files/world_countries_v1.geo.json"
-        }, 
-        {
-          "type": "topojson",
-          "url": "/files/world_countries_v7.topo.json",
-          "legacy_default": true,
-          "meta": {
-            "feature_collection_path": "data"
-          }
+          "url": "/files/world_countries_v1.geo.json",
+          "legacy_default": true
         }
       ],
       "fields": [
@@ -411,6 +404,177 @@
         "zh-my": "国家",
         "zh-sg": "国家",
         "zh-tw": "國家"
+      }
+    },
+    {
+      "layer_id": "administrative_regions_lvl2",
+      "created_at": "2020-07-06T22:19:49.290894",
+      "attribution": [
+        {
+          "label": {
+            "en": "Made with NaturalEarth"
+          },
+          "url": {
+            "en": "http://www.naturalearthdata.com/about/terms-of-use"
+          }
+        },
+        {
+          "label": {
+            "en": "© OpenStreetMap contributors"
+          },
+          "url": {
+            "en": "https://www.openstreetmap.org/copyright"
+          }
+        },
+        {
+          "label": {
+            "en": "Elastic Maps Service"
+          },
+          "url": {
+            "en": "https://www.elastic.co/elastic-maps-service"
+          }
+        }
+      ],
+      "formats": [
+        {
+          "type": "topojson",
+          "url": "/files/admin_regions_lvl2_v2.topo.json",
+          "legacy_default": true,
+          "meta": {
+            "feature_collection_path": "data"
+          }
+        },
+        {
+          "type": "geojson",
+          "url": "/files/admin_regions_lvl2_v2.geo.json",
+          "legacy_default": false
+        }
+      ],
+      "fields": [
+        {
+          "type": "id",
+          "id": "region_iso_code",
+          "label": {
+            "en": "Region ISO code"
+          }
+        },
+        {
+          "type": "property",
+          "id": "region_name",
+          "label": {
+            "en": "Region name"
+          }
+        }
+      ],
+      "legacy_ids": [
+        "Administrative regions"
+      ],
+      "layer_name": {
+        "ar": "تقسيم إداري",
+        "arz": "تقسيم ادارى",
+        "ast": "división alministrativa",
+        "az": "inzibati-ərazi vahidi",
+        "ba": "административ-территориаль берәмек",
+        "bar": "Vawoitungseihheit",
+        "be": "адміністрацыйна-тэрытарыяльная адзінка",
+        "be-tarask": "адміністрацыйная адзінка",
+        "bg": "административна единица",
+        "bn": "প্রশাসনিক বিভাগ",
+        "br": "Melestradurezh tiriadel",
+        "bs": "Entitet",
+        "ca": "entitat territorial administrativa",
+        "cs": "administrativní jednotka",
+        "cy": "endid tiriogaethol gweinyddol",
+        "da": "administrativt område",
+        "de": "administrativ-territoriale Entität",
+        "diq": "Mıntıqay letey idareyi",
+        "el": "διοικητική διαίρεση",
+        "en": "Administrative regions",
+        "en-ca": "Administrative regions",
+        "en-gb": "Administrative regions",
+        "eo": "administra teritoria unuo",
+        "es": "entidad territorial administrativa",
+        "et": "haldusüksus",
+        "eu": "lurraldeko administrazio-erakunde",
+        "fa": "تقسیمات کشوری",
+        "fi": "hallinnollinen alue",
+        "fr": "entité territoriale administrative",
+        "ga": "limistéar riaracháin",
+        "gl": "división administrativa",
+        "gsw": "Verwaltigseinheit",
+        "hak": "Hàng-chṳn khî-va̍k",
+        "he": "חלוקה מנהלית",
+        "hi": "प्रशासनिक प्रभाग",
+        "hr": "administrativni teritorijalni entitet",
+        "hsb": "administratiwno-teritorialna jednotka",
+        "ht": "Kolektivite tèritoryal",
+        "hu": "közigazgatási egység",
+        "hy": "վարչատարածքային միավոր",
+        "ia": "entitate territorial administrative",
+        "id": "pembagian administratif",
+        "is": "Stjórnsýslueining",
+        "it": "suddivisione amministrativa",
+        "ja": "行政区画",
+        "ka": "ადმინისტრაციული ერთეული",
+        "kk": "Әкімшілік-аумақтық бөлініс",
+        "kn": "ಆಡಳಿತ ಕೇಂದ್ರ",
+        "ko": "행정 구역",
+        "ky": "Административдик-аймактык түзүлүш",
+        "la": "divisio administrativa",
+        "lb": "administrativ-territorial Eenheet",
+        "lmo": "circoscriziù",
+        "lt": "Administracinis vienetas",
+        "lv": "administratīvi teritoriāla vienība",
+        "mk": "управна единица",
+        "mr": "प्रशासकीय विभाग",
+        "ms": "entiti wilayah pentadbiran",
+        "nan": "Hêng-chèng-khu",
+        "nb": "forvaltningsenhet",
+        "nds-nl": "bestuurlike indaeling",
+        "nl": "bestuurlijk gebied",
+        "nn": "administrativ eining",
+        "oc": "subdivision",
+        "pl": "jednostka administracyjna",
+        "pt": "entidade territorial administrativa",
+        "pt-br": "entidade territorial administrativa",
+        "ro": "Diviziune administrativă",
+        "ru": "административно-территориальная единица",
+        "scn": "entità tirrituriali amministrativa",
+        "sco": "admeenistrative diveesion",
+        "sd": "انتظامي ورھاست",
+        "sh": "Entitet",
+        "sk": "administratívny územný celok",
+        "sl": "administrativna območna enota",
+        "sq": "Ndarja administrative",
+        "sr": "управна јединица",
+        "sr-ec": "управна јединица",
+        "sr-el": "upravna jedinica",
+        "sv": "administrativ territoriell enhet",
+        "sw": "Eneo la utawala",
+        "te": "పరిపాలనా ప్రాంతం",
+        "tg": "Воҳиди марзиву маъмурӣ",
+        "tg-cyrl": "воҳиди марзию маъмурӣ",
+        "th": "เขตการปกครอง",
+        "tr": "idari bölünüş",
+        "tt": "административ-территориаль берәмлек",
+        "tt-cyrl": "административ-территориаль берәмлек",
+        "tt-latn": "administrativ-territorial' berämleq",
+        "uk": "адміністративно-територіальна одиниця",
+        "ur": "انتظامی علاقائی اکائی",
+        "uz": "Maʼmuriy-hududiy tuzilish",
+        "vi": "đơn vị hành chính",
+        "vro": "Valitsõmisütsüs",
+        "wuu": "行政区划",
+        "yue": "行政區",
+        "zh": "行政領土實體",
+        "zh-cn": "行政领土实体",
+        "zh-hans": "行政领土实体",
+        "zh-hant": "行政領土實體",
+        "zh-hk": "行政領土實體",
+        "zh-mo": "行政領土實體",
+        "zh-my": "行政领土实体",
+        "zh-sg": "行政领土实体",
+        "zh-tw": "行政領土實體"
       }
     },
     {

--- a/test/ems_mocks/sample_files_proxied.json
+++ b/test/ems_mocks/sample_files_proxied.json
@@ -24,15 +24,8 @@
       "formats": [
         {
           "type": "geojson",
-          "url": "/files/world_countries_v1.geo.json"
-        }, 
-        {
-          "type": "topojson",
-          "url": "/files/world_countries_v7.topo.json",
-          "legacy_default": true,
-          "meta": {
-            "feature_collection_path": "data"
-          }
+          "url": "/files/world_countries.json",
+          "legacy_default": true
         }
       ],
       "fields": [
@@ -411,6 +404,198 @@
         "zh-my": "国家",
         "zh-sg": "国家",
         "zh-tw": "國家"
+      }
+    },
+    {
+      "layer_id": "administrative_regions_lvl2",
+      "created_at": "2020-07-06T22:19:49.290894",
+      "attribution": [
+        {
+          "label": {
+            "en": "Made with NaturalEarth"
+          },
+          "url": {
+            "en": "http://www.naturalearthdata.com/about/terms-of-use"
+          }
+        },
+        {
+          "label": {
+            "en": "© OpenStreetMap contributors"
+          },
+          "url": {
+            "en": "https://www.openstreetmap.org/copyright"
+          }
+        },
+        {
+          "label": {
+            "en": "Elastic Maps Service"
+          },
+          "url": {
+            "en": "https://www.elastic.co/elastic-maps-service"
+          }
+        }
+      ],
+      "formats": [
+        {
+          "type": "topojson",
+          "url": "/files/admin_regions_lvl2_v2.topo.json",
+          "legacy_default": true,
+          "meta": {
+            "feature_collection_path": "data"
+          }
+        },
+        {
+          "type": "geojson",
+          "url": "/files/admin_regions_lvl2_v2.geo.json",
+          "legacy_default": false
+        }
+      ],
+      "fields": [
+        {
+          "type": "id",
+          "id": "region_iso_code",
+          "label": {
+            "en": "Region ISO code"
+          }
+        },
+        {
+          "type": "property",
+          "id": "region_name",
+          "label": {
+            "en": "Region name"
+          }
+        },
+        {
+          "type": "property",
+          "id": "country_iso2_code",
+          "label": {
+            "en": "Country ISO2 code"
+          }
+        },
+        {
+          "type": "property",
+          "id": "country_iso3_code",
+          "label": {
+            "en": "Country ISO3 code"
+          }
+        },
+        {
+          "type": "property",
+          "id": "country_name",
+          "label": {
+            "en": "Country name"
+          }
+        }
+      ],
+      "legacy_ids": [
+        "Administrative regions"
+      ],
+      "layer_name": {
+        "ar": "تقسيم إداري",
+        "arz": "تقسيم ادارى",
+        "ast": "división alministrativa",
+        "az": "inzibati-ərazi vahidi",
+        "ba": "административ-территориаль берәмек",
+        "bar": "Vawoitungseihheit",
+        "be": "адміністрацыйна-тэрытарыяльная адзінка",
+        "be-tarask": "адміністрацыйная адзінка",
+        "bg": "административна единица",
+        "bn": "প্রশাসনিক বিভাগ",
+        "br": "Melestradurezh tiriadel",
+        "bs": "Entitet",
+        "ca": "entitat territorial administrativa",
+        "cs": "administrativní jednotka",
+        "cy": "endid tiriogaethol gweinyddol",
+        "da": "administrativt område",
+        "de": "administrativ-territoriale Entität",
+        "diq": "Mıntıqay letey idareyi",
+        "el": "διοικητική διαίρεση",
+        "en": "Administrative regions",
+        "en-ca": "Administrative regions",
+        "en-gb": "Administrative regions",
+        "eo": "administra teritoria unuo",
+        "es": "entidad territorial administrativa",
+        "et": "haldusüksus",
+        "eu": "lurraldeko administrazio-erakunde",
+        "fa": "تقسیمات کشوری",
+        "fi": "hallinnollinen alue",
+        "fr": "entité territoriale administrative",
+        "ga": "limistéar riaracháin",
+        "gl": "división administrativa",
+        "gsw": "Verwaltigseinheit",
+        "hak": "Hàng-chṳn khî-va̍k",
+        "he": "חלוקה מנהלית",
+        "hi": "प्रशासनिक प्रभाग",
+        "hr": "administrativni teritorijalni entitet",
+        "hsb": "administratiwno-teritorialna jednotka",
+        "ht": "Kolektivite tèritoryal",
+        "hu": "közigazgatási egység",
+        "hy": "վարչատարածքային միավոր",
+        "ia": "entitate territorial administrative",
+        "id": "pembagian administratif",
+        "is": "Stjórnsýslueining",
+        "it": "suddivisione amministrativa",
+        "ja": "行政区画",
+        "ka": "ადმინისტრაციული ერთეული",
+        "kk": "Әкімшілік-аумақтық бөлініс",
+        "kn": "ಆಡಳಿತ ಕೇಂದ್ರ",
+        "ko": "행정 구역",
+        "ky": "Административдик-аймактык түзүлүш",
+        "la": "divisio administrativa",
+        "lb": "administrativ-territorial Eenheet",
+        "lmo": "circoscriziù",
+        "lt": "Administracinis vienetas",
+        "lv": "administratīvi teritoriāla vienība",
+        "mk": "управна единица",
+        "mr": "प्रशासकीय विभाग",
+        "ms": "entiti wilayah pentadbiran",
+        "nan": "Hêng-chèng-khu",
+        "nb": "forvaltningsenhet",
+        "nds-nl": "bestuurlike indaeling",
+        "nl": "bestuurlijk gebied",
+        "nn": "administrativ eining",
+        "oc": "subdivision",
+        "pl": "jednostka administracyjna",
+        "pt": "entidade territorial administrativa",
+        "pt-br": "entidade territorial administrativa",
+        "ro": "Diviziune administrativă",
+        "ru": "административно-территориальная единица",
+        "scn": "entità tirrituriali amministrativa",
+        "sco": "admeenistrative diveesion",
+        "sd": "انتظامي ورھاست",
+        "sh": "Entitet",
+        "sk": "administratívny územný celok",
+        "sl": "administrativna območna enota",
+        "sq": "Ndarja administrative",
+        "sr": "управна јединица",
+        "sr-ec": "управна јединица",
+        "sr-el": "upravna jedinica",
+        "sv": "administrativ territoriell enhet",
+        "sw": "Eneo la utawala",
+        "te": "పరిపాలనా ప్రాంతం",
+        "tg": "Воҳиди марзиву маъмурӣ",
+        "tg-cyrl": "воҳиди марзию маъмурӣ",
+        "th": "เขตการปกครอง",
+        "tr": "idari bölünüş",
+        "tt": "административ-территориаль берәмлек",
+        "tt-cyrl": "административ-территориаль берәмлек",
+        "tt-latn": "administrativ-territorial' berämleq",
+        "uk": "адміністративно-територіальна одиниця",
+        "ur": "انتظامی علاقائی اکائی",
+        "uz": "Maʼmuriy-hududiy tuzilish",
+        "vi": "đơn vị hành chính",
+        "vro": "Valitsõmisütsüs",
+        "wuu": "行政区划",
+        "yue": "行政區",
+        "zh": "行政領土實體",
+        "zh-cn": "行政领土实体",
+        "zh-hans": "行政领土实体",
+        "zh-hant": "行政領土實體",
+        "zh-hk": "行政領土實體",
+        "zh-mo": "行政領土實體",
+        "zh-my": "行政领土实体",
+        "zh-sg": "行政领土实体",
+        "zh-tw": "行政領土實體"
       }
     }
   ]}

--- a/test/ems_mocks/sample_files_proxied.json
+++ b/test/ems_mocks/sample_files_proxied.json
@@ -24,8 +24,15 @@
       "formats": [
         {
           "type": "geojson",
-          "url": "/files/world_countries.json",
-          "legacy_default": true
+          "url": "/files/world_countries_v1.geo.json"
+        }, 
+        {
+          "type": "topojson",
+          "url": "/files/world_countries_v7.topo.json",
+          "legacy_default": true,
+          "meta": {
+            "feature_collection_path": "data"
+          }
         }
       ],
       "fields": [


### PR DESCRIPTION
The EMS file service supports multiple geospatial formats for file services. This PR introduces several new functions for retrieving a specific format for a layer. If the requested format is unavailable it falls back to the default format.

This PR is required for https://github.com/elastic/ems-landing-page/issues/255.

See also https://github.com/elastic/ems-file-service/issues/191
