### PR TITLE
Add function to retrieve and cache vector files

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     }
   },
   "dependencies": {
+    "@types/geojson": "^7946.0.7",
+    "@types/topojson-specification": "^1.0.1",
     "lodash": "^4.17.15",
     "semver": "7.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -36,9 +36,13 @@
   },
   "dependencies": {
     "@types/geojson": "^7946.0.7",
+    "@types/lru-cache": "^5.1.0",
+    "@types/topojson-client": "^3.0.0",
     "@types/topojson-specification": "^1.0.1",
     "lodash": "^4.17.15",
-    "semver": "7.3.2"
+    "lru-cache": "^6.0.0",
+    "semver": "7.3.2",
+    "topojson-client": "^3.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.6.4",

--- a/src/ems_client.ts
+++ b/src/ems_client.ts
@@ -277,7 +277,15 @@ export class EMSClient {
    */
   async getManifest<T>(manifestUrl: string): Promise<T> {
     try {
-      const url = extendUrl(manifestUrl, { query: this._queryParams });
+      return await this.getJsonEndpoint(manifestUrl);
+    } catch (e) {
+      throw new Error(`Unable to retrieve manifest from ${manifestUrl}: ${e.message}`);
+    }
+  }
+
+  async getJsonEndpoint<T>(endpointUrl: string): Promise<T> {
+    try {
+      const url = extendUrl(endpointUrl, { query: this._queryParams });
       const result = await this._fetchWithTimeout(url);
       return result ? await result.json() : null;
     } catch (e) {
@@ -287,7 +295,7 @@ export class EMSClient {
       if (!(e instanceof Error)) {
         e = new Error(e.data || `status ${e.statusText || e.status}`);
       }
-      throw new Error(`Unable to retrieve manifest from ${manifestUrl}: ${e.message}`);
+      throw new Error(`Unable to retrieve data from ${endpointUrl}: ${e.message}`);
     }
   }
 

--- a/src/file_layer.ts
+++ b/src/file_layer.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import _ from 'lodash';
 import url from 'url';
 import {
   EMSClient,
@@ -25,6 +26,8 @@ import {
   FileLayerConfig,
 } from './ems_client';
 import { AbstractEmsService } from './ems_service';
+import { FeatureCollection } from 'geojson';
+import { TopoJSON } from 'topojson-specification';
 
 export enum EMSFormatType {
   geojson = 'geojson',
@@ -37,9 +40,29 @@ type EMSFormats = EmsFileLayerFormatGeoJson | EmsFileLayerFormatTopoJson;
 export class FileLayer extends AbstractEmsService {
   protected readonly _config: FileLayerConfig;
 
+  private _getVectorDataOfType = _.memoize(
+    async (format: EMSFormatTypeStrings): Promise<FeatureCollection | TopoJSON | undefined> => {
+      const fileUrl = this.getFormatOfTypeUrl(format);
+      if (fileUrl) {
+        const vectorJson = await this._emsClient.getJsonEndpoint<
+          FeatureCollection | TopoJSON | undefined
+        >(fileUrl);
+        return vectorJson;
+      } else {
+        return;
+      }
+    }
+  );
+
   constructor(config: FileLayerConfig, emsClient: EMSClient, proxyPath: string) {
     super(config, emsClient, proxyPath);
     this._config = config;
+  }
+
+  async getVectorDataOfType(
+    format: EMSFormatTypeStrings
+  ): Promise<FeatureCollection | TopoJSON | undefined> {
+    return await this._getVectorDataOfType(format);
   }
 
   getFields(): FileLayerConfig['fields'] {

--- a/test/__snapshots__/ems_client.test.ts.snap
+++ b/test/__snapshots__/ems_client.test.ts.snap
@@ -1,0 +1,83 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.getFileLayers[1] - getGeoJson defaults should convert topojson to geojson 1`] = `
+Object {
+  "features": Array [
+    Object {
+      "geometry": Object {
+        "coordinates": Array [
+          Array [
+            Array [
+              72.77144284428442,
+              62.593,
+            ],
+            Array [
+              50.625,
+              50.06444104410441,
+            ],
+            Array [
+              91.7565793579358,
+              35.46,
+            ],
+            Array [
+              93.867,
+              58.2621401140114,
+            ],
+            Array [
+              72.77144284428442,
+              62.593,
+            ],
+          ],
+        ],
+        "type": "Polygon",
+      },
+      "properties": Object {
+        "foo": "bar",
+      },
+      "type": "Feature",
+    },
+  ],
+  "type": "FeatureCollection",
+}
+`;
+
+exports[`.getFileLayers[1] - getGeoJson limited cache 1`] = `
+Object {
+  "features": Array [
+    Object {
+      "geometry": Object {
+        "coordinates": Array [
+          Array [
+            Array [
+              72.77144284428442,
+              62.593,
+            ],
+            Array [
+              50.625,
+              50.06444104410441,
+            ],
+            Array [
+              91.7565793579358,
+              35.46,
+            ],
+            Array [
+              93.867,
+              58.2621401140114,
+            ],
+            Array [
+              72.77144284428442,
+              62.593,
+            ],
+          ],
+        ],
+        "type": "Polygon",
+      },
+      "properties": Object {
+        "foo": "bar",
+      },
+      "type": "Feature",
+    },
+  ],
+  "type": "FeatureCollection",
+}
+`;

--- a/test/ems_client.test.ts
+++ b/test/ems_client.test.ts
@@ -282,6 +282,32 @@ describe('ems_client', () => {
     );
   });
 
+  it('.getFileLayers[1] - caches json response', async () => {
+    const emsClient = getEMSClient({
+      language: 'en',
+      tileApiUrl: 'https://tiles.foobar',
+      fileApiUrl: 'https://files.foobar',
+      emsVersion: '7.13',
+    });
+
+    const spy = spyOn(emsClient, 'getJsonEndpoint');
+
+    const layers = await emsClient.getFileLayers();
+    const layer = layers[1];
+
+    await layer.getVectorDataOfType('topojson');
+    await layer.getVectorDataOfType('topojson');
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(
+      'https://files.foobar/files/admin_regions_lvl2_v2.topo.json?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x'
+    );
+    await layer.getVectorDataOfType('geojson');
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledWith(
+      'https://files.foobar/files/admin_regions_lvl2_v2.geo.json?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x'
+    );
+  });
+
   it('.findFileLayerById', async () => {
     const emsClient = getEMSClient({
       language: 'zz', //madeup

--- a/test/ems_client_util.ts
+++ b/test/ems_client_util.ts
@@ -23,6 +23,8 @@ import fetch from 'node-fetch';
 import EMS_CATALOGUE from './ems_mocks/sample_manifest.json';
 import EMS_FILES from './ems_mocks/sample_files.json';
 import EMS_TILES from './ems_mocks/sample_tiles.json';
+import EMS_TOPOJSON from './ems_mocks/sample_topojson.json';
+import EMS_GEOJSON from './ems_mocks/sample_geojson.json';
 import EMS_STYLE_ROAD_MAP_BRIGHT from './ems_mocks/sample_style_bright.json';
 import EMS_STYLE_BRIGHT_PROXIED from './ems_mocks/sample_style_bright_proxied.json';
 import EMS_STYLE_BRIGHT_VECTOR_PROXIED from './ems_mocks/sample_style_bright_vector_proxied.json';
@@ -50,43 +52,57 @@ export function getEMSClient(options = {}) {
     ...options,
   });
 
-  emsClient.getManifest = async (url: string): Promise<any> => {
-    //simulate network calls
-    if (url.startsWith('https://foobar')) {
-      return EMS_CATALOGUE;
-    } else if (url.startsWith('https://tiles.foobar')) {
-      if (url.includes('/manifest')) {
-        return EMS_TILES;
-      } else if (url.includes('osm-bright/style.json')) {
-        return EMS_STYLE_ROAD_MAP_BRIGHT_VECTOR;
-      } else if (url.includes('osm-bright-desaturated.json')) {
-        return EMS_STYLE_ROAD_MAP_DESATURATED;
-      } else if (url.includes('osm-bright.json')) {
-        return EMS_STYLE_ROAD_MAP_BRIGHT;
-      } else if (url.includes('dark-matter.json')) {
-        return EMS_STYLE_DARK_MAP;
-      } else if (url.includes('/data/v3.json')) {
-        return EMS_STYLE_ROAD_MAP_BRIGHT_VECTOR_SOURCE;
+  const getManifestMock = jest.spyOn(emsClient, 'getManifest').mockImplementation(
+    async (url: string): Promise<any> => {
+      //simulate network calls
+      if (url.startsWith('https://foobar')) {
+        return EMS_CATALOGUE;
+      } else if (url.startsWith('https://tiles.foobar')) {
+        if (url.includes('/manifest')) {
+          return EMS_TILES;
+        } else if (url.includes('osm-bright/style.json')) {
+          return EMS_STYLE_ROAD_MAP_BRIGHT_VECTOR;
+        } else if (url.includes('osm-bright-desaturated.json')) {
+          return EMS_STYLE_ROAD_MAP_DESATURATED;
+        } else if (url.includes('osm-bright.json')) {
+          return EMS_STYLE_ROAD_MAP_BRIGHT;
+        } else if (url.includes('dark-matter.json')) {
+          return EMS_STYLE_DARK_MAP;
+        } else if (url.includes('/data/v3.json')) {
+          return EMS_STYLE_ROAD_MAP_BRIGHT_VECTOR_SOURCE;
+        }
+      } else if (url.startsWith('https://files.foobar')) {
+        if (url.includes('/manifest')) {
+          return EMS_FILES;
+        } else if (url.includes('topo.json')) {
+          return EMS_TOPOJSON;
+        } else if (url.includes('geo.json')) {
+          return EMS_GEOJSON;
+        }
+      } else if (url.startsWith('http://proxy.com/foobar/manifest')) {
+        return EMS_CATALOGUE_PROXIED;
+      } else if (url.startsWith('http://proxy.com/foobar/vector')) {
+        if (url.includes('/manifest')) {
+          return EMS_FILES_PROXIED;
+        } else if (url.includes('topo.json')) {
+          return EMS_TOPOJSON;
+        } else if (url.includes('geo.json')) {
+          return EMS_GEOJSON;
+        }
+      } else if (url.startsWith('http://proxy.com/foobar/tiles')) {
+        if (url.includes('manifest')) {
+          return EMS_TILES_PROXIED;
+        } else if (url.includes('/data/v3.json')) {
+          return EMS_STYLE_ROAD_MAP_BRIGHT_VECTOR_SOURCE_PROXIED;
+        } else if (url.includes('osm-bright.json')) {
+          return EMS_STYLE_BRIGHT_PROXIED;
+        } else if (url.includes('osm-bright/style.json')) {
+          return EMS_STYLE_BRIGHT_VECTOR_PROXIED;
+        }
+      } else {
+        throw new Error(`url unexpected: ${url}`);
       }
-    } else if (url.startsWith('https://files.foobar')) {
-      return EMS_FILES;
-    } else if (url.startsWith('http://proxy.com/foobar/manifest')) {
-      return EMS_CATALOGUE_PROXIED;
-    } else if (url.startsWith('http://proxy.com/foobar/vector')) {
-      return EMS_FILES_PROXIED;
-    } else if (url.startsWith('http://proxy.com/foobar/tiles')) {
-      if (url.includes('manifest')) {
-        return EMS_TILES_PROXIED;
-      } else if (url.includes('/data/v3.json')) {
-        return EMS_STYLE_ROAD_MAP_BRIGHT_VECTOR_SOURCE_PROXIED;
-      } else if (url.includes('osm-bright.json')) {
-        return EMS_STYLE_BRIGHT_PROXIED;
-      } else if (url.includes('osm-bright/style.json')) {
-        return EMS_STYLE_BRIGHT_VECTOR_PROXIED;
-      }
-    } else {
-      throw new Error(`url unexpected: ${url}`);
     }
-  };
-  return emsClient;
+  );
+  return { emsClient, getManifestMock };
 }

--- a/test/ems_mocks/sample_geojson.json
+++ b/test/ems_mocks/sample_geojson.json
@@ -1,0 +1,23 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "foo": "bar"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [72.773, 62.593],
+            [50.625, 50.064],
+            [91.757, 35.46],
+            [93.867, 58.263],
+            [72.773, 62.593]
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/test/ems_mocks/sample_topojson.json
+++ b/test/ems_mocks/sample_topojson.json
@@ -1,0 +1,23 @@
+{
+  "type": "Topology",
+  "objects": {
+    "data": {
+      "type": "GeometryCollection",
+      "geometries": [{ "type": "Polygon", "properties": { "foo": "bar" }, "arcs": [[0]] }]
+    }
+  },
+  "arcs": [
+    [
+      [5121, 9999],
+      [-5121, -4617],
+      [9511, -5382],
+      [488, 8403],
+      [-4878, 1596]
+    ]
+  ],
+  "transform": {
+    "scale": [0.004324632463246325, 0.002713571357135714],
+    "translate": [50.625, 35.46]
+  },
+  "bbox": [50.625, 35.46, 93.867, 62.593]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1203,6 +1203,11 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.165.tgz#74d55d947452e2de0742bad65270433b63a8c30f"
   integrity sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg==
 
+"@types/lru-cache@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.0.tgz#57f228f2b80c046b4a1bd5cac031f81f207f4f03"
+  integrity sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w==
+
 "@types/node-fetch@^2.5.7":
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.7.tgz#20a2afffa882ab04d44ca786449a276f9f6bbf3c"
@@ -1246,7 +1251,15 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
 
-"@types/topojson-specification@^1.0.1":
+"@types/topojson-client@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/topojson-client/-/topojson-client-3.0.0.tgz#2517fae5abbdd3052eb191747c7d0bc268d69918"
+  integrity sha512-HZH6E8XMhjkDEkkpe3HuIg95COuvjdnyy0EKrh8rAi1f6o/V6P3ly1kGyU2E8bpAffXDd2r+Rk5ceMX4XkqHnA==
+  dependencies:
+    "@types/geojson" "*"
+    "@types/topojson-specification" "*"
+
+"@types/topojson-specification@*", "@types/topojson-specification@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/topojson-specification/-/topojson-specification-1.0.1.tgz#a80cb294290b79f2d674d3f5938c544ed2bd9d80"
   integrity sha512-ZZYZUgkmUls9Uhxx2WZNt9f/h2+H3abUUjOVmq+AaaDFckC5oAwd+MDp95kBirk+XCXrYj0hfpI6DSUiJMrpYQ==
@@ -1841,6 +1854,11 @@ combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@2:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 commander@^4.0.1:
   version "4.1.1"
@@ -4824,6 +4842,13 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+topojson-client@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/topojson-client/-/topojson-client-3.1.0.tgz#22e8b1ed08a2b922feeb4af6f53b6ef09a467b99"
+  integrity sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==
+  dependencies:
+    commander "2"
 
 tough-cookie@^2.3.3, tough-cookie@~2.5.0:
   version "2.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1154,6 +1154,11 @@
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
+"@types/geojson@*", "@types/geojson@^7946.0.7":
+  version "7946.0.7"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.7.tgz#c8fa532b60a0042219cdf173ca21a975ef0666ad"
+  integrity sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.4.tgz#4ff9f641a7c6d1a3508ff88bc3141b152772e753"
@@ -1240,6 +1245,13 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
+
+"@types/topojson-specification@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/topojson-specification/-/topojson-specification-1.0.1.tgz#a80cb294290b79f2d674d3f5938c544ed2bd9d80"
+  integrity sha512-ZZYZUgkmUls9Uhxx2WZNt9f/h2+H3abUUjOVmq+AaaDFckC5oAwd+MDp95kBirk+XCXrYj0hfpI6DSUiJMrpYQ==
+  dependencies:
+    "@types/geojson" "*"
 
 "@types/yargs-parser@*":
   version "15.0.0"


### PR DESCRIPTION
Fixes #60. The `getVectorDataOfType` function takes either a `geojson` or `topojson` argument and retrieves and caches the specified vector file from EMS.

This is similar to how the vector tile stylesheets are cached. For file layers we use the `memoize` function rather than the `once` function because the argument may differ between function calls.

Note: Reviewers may want to hide whitespace changes. 