### PR TITLE
Refer explicitly to Elastic License v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "elastic maps service"
   ],
   "author": "Nick Peihl <nick.peihl@elastic.co>",
-  "license": "SEE LICENSE IN LICENSE.txt",
+  "license": "Elastic License 2.0",
   "bugs": {
     "url": "https://github.com/elastic/ems-client/issues"
   },


### PR DESCRIPTION
As discussed in the Kibana issue https://github.com/elastic/kibana/issues/102909 the current license statement in our `package.json` is needing an unnecessary override https://github.com/elastic/kibana/blob/master/src/dev/license_checker/config.ts#L76

This change should also make the license explicit in npm.js

![image](https://user-images.githubusercontent.com/188264/123126183-7674cf80-d449-11eb-86f0-b9ab619995a8.png)
