### PR TITLE
Better fetch error handling

### DIFF
--- a/src/file_layer.ts
+++ b/src/file_layer.ts
@@ -41,7 +41,6 @@ export class FileLayer extends AbstractEmsService {
 
     const format = this.getDefaultFormatType();
     const fetchUrl = this.getDefaultFormatUrl();
-    // let fetchedJson;
     let geojson;
     const fetchedJson = await this._emsClient.getManifest(fetchUrl);
     if (fetchedJson) {


### PR DESCRIPTION
This should simplify error handling with fetch. It will throw early if the response is not ok (ex. 404). Otherwise it tries to parse a non-JSON response and the error is less helpful.