### PR TITLE
Add optional `format` argument to getMinZoom getMaxZoom methods

### DIFF
--- a/src/tms_service.ts
+++ b/src/tms_service.ts
@@ -193,21 +193,37 @@ export class TMSService extends AbstractEmsService {
     return this._emsClient.getValueInLanguage(this._config.name);
   }
 
-  async getMinZoom(): Promise<number | undefined> {
-    const tileJson = await this._getRasterStyleJson();
-    if (tileJson) {
-      return tileJson.minzoom;
-    } else {
-      return;
+  async getMinZoom(format = 'vector'): Promise<number | undefined> {
+    switch (format) {
+      case 'vector':
+        const { sources } = (await this._getVectorStyleJsonInlined()) || { sources: {} };
+        return Math.min(
+          ...Object.values(sources)
+            .map(({ minzoom }) => minzoom)
+            .filter((minzoom): minzoom is number => Number.isFinite(minzoom))
+        );
+      case 'raster':
+        const { minzoom } = (await this._getRasterStyleJson()) || {};
+        return minzoom;
+      default:
+        return;
     }
   }
 
-  async getMaxZoom(): Promise<number | undefined> {
-    const tileJson = await this._getRasterStyleJson();
-    if (tileJson) {
-      return tileJson.maxzoom;
-    } else {
-      return;
+  async getMaxZoom(format = 'vector'): Promise<number | undefined> {
+    switch (format) {
+      case 'vector':
+        const { sources } = (await this._getVectorStyleJsonInlined()) || { sources: {} };
+        return Math.max(
+          ...Object.values(sources)
+            .map(({ maxzoom }) => maxzoom)
+            .filter((maxzoom): maxzoom is number => Number.isFinite(maxzoom))
+        );
+      case 'raster':
+        const { maxzoom } = (await this._getRasterStyleJson()) || {};
+        return maxzoom;
+      default:
+        return;
     }
   }
 

--- a/test/ems_client.test.ts
+++ b/test/ems_client.test.ts
@@ -52,8 +52,15 @@ it('should get the tile service', async () => {
     'https://tiles.foobar/raster/styles/osm-bright/{z}/{x}/{y}.png?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x'
   );
 
-  expect(await tileService.getMinZoom()).toBe(0);
-  expect(await tileService.getMaxZoom()).toBe(10);
+  expect(await tileService.getUrlTemplateForVector('openmaptiles')).toBe(
+    'https://tiles.foobar/data/v3/{z}/{x}/{y}.pbf?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x'
+  );
+
+  expect(await tileService.getMinZoom('raster')).toBe(0);
+  expect(await tileService.getMaxZoom('raster')).toBe(10);
+
+  expect(await tileService.getMinZoom('vector')).toBe(3);
+  expect(await tileService.getMaxZoom('vector')).toBe(15);
   expect(tileService.hasId('road_map')).toBe(true);
 });
 
@@ -73,8 +80,8 @@ it('tile service- localized (fallback)', async () => {
     'https://tiles.foobar/raster/styles/osm-bright/{z}/{x}/{y}.png?elastic_tile_service_tos=agree&my_app_name=tester&my_app_version=7.x.x'
   );
 
-  expect(await tileService.getMinZoom()).toBe(0);
-  expect(await tileService.getMaxZoom()).toBe(10);
+  expect(await tileService.getMinZoom('raster')).toBe(0);
+  expect(await tileService.getMaxZoom('raster')).toBe(10);
   expect(tileService.hasId('road_map')).toBe(true);
 });
 

--- a/test/ems_mocks/sample_style_bright_vector_source.json
+++ b/test/ems_mocks/sample_style_bright_vector_source.json
@@ -19,8 +19,8 @@
     4
   ],
   "description": "A tileset showcasing all layers in OpenMapTiles. https://openmaptiles.org",
-  "maxzoom": 10,
-  "minzoom": 0,
+  "maxzoom": 15,
+  "minzoom": 3,
   "pixel_scale": "256",
   "vector_layers": [
     {


### PR DESCRIPTION
This allows the user to optionally specify either `raster` or `vector` when using `getMinZoom` and `getMaxZoom` methods. If not specified, the `vector` format is used.

Previously, these methods only looked at the raster tile manifest which may have different zoom levels than the vector tiles. Since vector tiles are default in downstream clients, I think we should use the vector tiles manifest by default.