### PR TITLE
Remove copyright character from layer attributions

### DIFF
--- a/src/ems_service.ts
+++ b/src/ems_service.ts
@@ -33,7 +33,9 @@ export abstract class AbstractEmsService implements IEmsService {
   getAttributions(): { url: string; label: string }[] {
     return this._config.attribution.map((attribution) => {
       const url = this._emsClient.getValueInLanguage(attribution.url);
-      const label = this._emsClient.getValueInLanguage(attribution.label);
+      const attLabel = this._emsClient.getValueInLanguage(attribution.label);
+      const label = attLabel.replace('©', '').trim();
+
       return {
         url: url,
         label: label,
@@ -42,9 +44,7 @@ export abstract class AbstractEmsService implements IEmsService {
   }
 
   getMarkdownAttribution(): string {
-    const attributions = this._config.attribution.map((attribution) => {
-      const url = this._emsClient.getValueInLanguage(attribution.url);
-      const label = this._emsClient.getValueInLanguage(attribution.label);
+    const attributions = this.getAttributions().map(({ url, label }) => {
       return `[${label}](${url})`;
     });
     return attributions.join('|');

--- a/test/ems_client.test.ts
+++ b/test/ems_client.test.ts
@@ -459,3 +459,17 @@ it('should retrieve vectorstylesheet with all sources inlined) (proxy)', async (
   );
   expect(styleSheet!.sources!.openmaptiles!.type).toBe('vector');
 });
+
+it('Attributions should not have any copyright character', async () => {
+  const { emsClient } = getEMSClient({
+    language: 'zz', //madeup
+    tileApiUrl: 'https://tiles.foobar',
+    fileApiUrl: 'https://files.foobar',
+    emsVersion: '7.6',
+  });
+
+  const tmsServices = await emsClient.getTMSServices();
+  const tmsWithAtts = tmsServices.filter((tms) => tms.getMarkdownAttribution().indexOf('©') > -1);
+
+  expect(tmsWithAtts.length).toBe(0);
+});

--- a/test/ems_client.test.ts
+++ b/test/ems_client.test.ts
@@ -469,7 +469,14 @@ it('Attributions should not have any copyright character', async () => {
   });
 
   const tmsServices = await emsClient.getTMSServices();
-  const tmsWithAtts = tmsServices.filter((tms) => tms.getMarkdownAttribution().indexOf('©') > -1);
+  const tmsWithAtts = tmsServices.filter(
+    (tms) =>
+      tms
+        .getAttributions()
+        .map(({ label }) => label)
+        .join('|')
+        .indexOf('©') > -1
+  );
 
   expect(tmsWithAtts.length).toBe(0);
 });

--- a/test/ems_mocks/sample_tiles.json
+++ b/test/ems_mocks/sample_tiles.json
@@ -5,7 +5,7 @@
       "name": { "en": "Road Map - Bright" },
       "attribution": [
         {
-          "label": { "en": "OpenStreetMap contributors" },
+          "label": { "en": "© OpenStreetMap contributors" },
           "url": { "en": "https://www.openstreetmap.org/copyright" }
         },
         { "label": { "en": "OpenMapTiles" }, "url": { "en": "https://openmaptiles.org" } },
@@ -33,7 +33,7 @@
       "name": { "en": "Road Map" },
       "attribution": [
         {
-          "label": { "en": "OpenStreetMap contributors" },
+          "label": { "en": "© OpenStreetMap contributors" },
           "url": { "en": "https://www.openstreetmap.org/copyright" }
         },
         { "label": { "en": "OpenMapTiles" }, "url": { "en": "https://openmaptiles.org" } },
@@ -61,7 +61,7 @@
       "name": { "en": "Dark Map" },
       "attribution": [
         {
-          "label": { "en": "OpenStreetMap contributors" },
+          "label": { "en": "© OpenStreetMap contributors" },
           "url": { "en": "https://www.openstreetmap.org/copyright" }
         },
         { "label": { "en": "OpenMapTiles" }, "url": { "en": "https://openmaptiles.org" } },

--- a/test/ems_mocks/sample_tiles_proxied.json
+++ b/test/ems_mocks/sample_tiles_proxied.json
@@ -5,7 +5,7 @@
       "name": { "en": "Road Map - Bright" },
       "attribution": [
         {
-          "label": { "en": "OpenStreetMap contributors" },
+          "label": { "en": "© OpenStreetMap contributors" },
           "url": { "en": "https://www.openstreetmap.org/copyright" }
         },
         { "label": { "en": "OpenMapTiles" }, "url": { "en": "https://openmaptiles.org" } },


### PR DESCRIPTION
Since an attribution is already somehow a copyright statement, we can remove the copyright to help removing duplicates from map attributions control.
