### PR TITLE
Update backport config

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,5 +1,25 @@
 {
   "upstream": "elastic/ems-client",
-  "branches": [{ "name": "7.x", "checked": true }, "7.2", "7.6", "7.7", "7.8", "7.9"],
-  "labels": ["backport"]
+  "branches": [
+    {
+      "name": "8.0",
+      "checked": true
+    },
+    "7.17",
+    "7.16",
+    "7.16",
+    "7.15",
+    "7.14",
+    "7.12",
+    "7.11",
+    "7.10",
+    "7.9",
+    "7.8",
+    "7.7",
+    "7.6",
+    "7.2"
+  ],
+  "labels": [
+    "backport"
+  ]
 }


### PR DESCRIPTION
Update backport config file to include all branches, setting `8.0` as checked by default. 
