### PR TITLE
[ci] Add status context to PR job definition

### DIFF
--- a/.ci/jobs/elastic+ems-client+pull-request.yml
+++ b/.ci/jobs/elastic+ems-client+pull-request.yml
@@ -15,4 +15,5 @@
         allow-whitelist-orgs-as-admins: true
         github-hooks: true
         cancel-builds-on-update: true
+        status-context: ems-client
     publishers: []


### PR DESCRIPTION
CI is not reporting back when running the jobs for Pull Requests, this change should reconnect the reporting with the PR.
