### PR TITLE
Export blendMode type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@
 export { EMSClient, FileLayerField } from './ems_client';
 export { FileLayer } from './file_layer';
 export { TMSService, EmsSprite, EmsSpriteSheet } from './tms_service';
+export { blendMode } from './utils';


### PR DESCRIPTION
Fixes #110

Exports the `blendMode` type for users of the `TMSService.transformColorProperties` method.
