### PR TITLE
Fix transforming color definitions with stops

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,7 +76,7 @@ function transformColor(paintColor: mbColorDefinition, func: Function): mbColorD
       const newColor = transformColor(stop[1], func);
       return [stop[0], newColor];
     });
-    const newPaintColor = { ...paintColor, ...stops };
+    const newPaintColor = Object.assign({}, paintColor, { stops });
     return newPaintColor;
   } else return paintColor;
 }

--- a/test/ems_client_colour.test.ts
+++ b/test/ems_client_colour.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { LayerSpecification } from 'maplibre-gl';
+import { FillLayerSpecification, LayerSpecification } from 'maplibre-gl';
 import { TMSService } from '../src';
 import { mlLayerTypes } from './ems_client_util';
 import chroma from 'chroma-js';
@@ -75,5 +75,40 @@ describe('Transform colours', () => {
         property: 'text-color',
       },
     ]);
+  });
+
+  it('should work with color expressions with stops', () => {
+    const inColor = chroma('#D36086');
+    const fillColors = [chroma('rgba(0,0,0,1)'), chroma('rgba(255,0,0,1)')];
+    const inOp = 'lighten';
+
+    const outColors = fillColors.map((fillColor) => {
+      return chroma.blend(fillColor, inColor, inOp);
+    });
+
+    const transform = TMSService.transformColorProperties;
+
+    const layerWithTextColor = {
+      id: 'layer',
+      type: 'fill',
+      source: '',
+      paint: {
+        'fill-color': {
+          base: 1,
+          stops: fillColors.map((fillColor) => {
+            return [1, chroma2css(fillColor)];
+          }),
+        } as unknown,
+      },
+    } as FillLayerSpecification;
+
+    const { color } = transform(layerWithTextColor, inColor.hex('rgba'), inOp, 0)[0];
+
+    expect(color).toEqual({
+      base: 1,
+      stops: outColors.map((fillColor) => {
+        return [1, chroma2css(fillColor)];
+      }),
+    });
   });
 });


### PR DESCRIPTION
The result of `transformColor` was incorrect for colors defined as objects with `stops`. This PR fixes the output and includes a test.
