### PR TITLE
Support color to be undefined

### DIFF
--- a/src/tms_service.ts
+++ b/src/tms_service.ts
@@ -220,8 +220,8 @@ export class TMSService extends AbstractEmsService {
   */
   public static transformColorProperties(
     layer: LayerSpecification,
-    color: string | undefined,
-    operation: blendMode,
+    color?: string,
+    operation?: blendMode,
     percentage?: number
   ): { property: keyof layerPaintProperty; color: mbColorDefinition | undefined }[] {
     if (['background', 'fill', 'line', 'symbol'].indexOf(layer.type) !== -1 && layer.paint) {

--- a/src/tms_service.ts
+++ b/src/tms_service.ts
@@ -220,7 +220,7 @@ export class TMSService extends AbstractEmsService {
   */
   public static transformColorProperties(
     layer: LayerSpecification,
-    color: string,
+    color: string | undefined,
     operation: blendMode,
     percentage?: number
   ): { property: keyof layerPaintProperty; color: mbColorDefinition | undefined }[] {
@@ -250,7 +250,10 @@ export class TMSService extends AbstractEmsService {
         const paintColor = paint[type];
         return {
           property: type,
-          color: paintColor ? colorizeColor(paintColor, color, operation, percentage) : paintColor,
+          color:
+            paintColor && color
+              ? colorizeColor(paintColor, color, operation, percentage)
+              : paintColor,
         };
       });
     } else {

--- a/test/ems_client_colour.test.ts
+++ b/test/ems_client_colour.test.ts
@@ -132,7 +132,7 @@ describe('Transform colours', () => {
       } as unknown,
     } as FillLayerSpecification;
 
-    const { color, property } = transform(layerWithFillColor, undefined, 'lighten', 0)[0];
+    const { color, property } = transform(layerWithFillColor)[0];
 
     expect(property).toEqual('fill-color');
     expect(color).toEqual(fillColorPaint);

--- a/test/ems_client_colour.test.ts
+++ b/test/ems_client_colour.test.ts
@@ -111,4 +111,30 @@ describe('Transform colours', () => {
       }),
     });
   });
+
+  it('should return the same colors if no input color is specified', () => {
+    const fillColors = ['#ff0000', '#00ff00', '#0000ff'];
+
+    const transform = TMSService.transformColorProperties;
+
+    const fillColorPaint = {
+      base: 1,
+      stops: fillColors.map((fillColor) => {
+        return [1, fillColor];
+      }),
+    };
+
+    const layerWithFillColor = {
+      id: 'layer',
+      type: 'fill',
+      paint: {
+        'fill-color': fillColorPaint,
+      } as unknown,
+    } as FillLayerSpecification;
+
+    const { color, property } = transform(layerWithFillColor, undefined, 'lighten', 0)[0];
+
+    expect(property).toEqual('fill-color');
+    expect(color).toEqual(fillColorPaint);
+  });
 });


### PR DESCRIPTION
Fixes #116 by accepting `undefined` color that will just return the properties with the original input color from the style definition.
