### PR TITLE
[8.3] Export blendMode type (#111) | Fix transforming color definitions with stops (#112) | Make percentage an optional parameter (#117) | Support color to be undefined (#118)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@
 export { EMSClient, FileLayerField } from './ems_client';
 export { FileLayer } from './file_layer';
 export { TMSService, EmsSprite, EmsSpriteSheet } from './tms_service';
+export { blendMode } from './utils';

--- a/src/tms_service.ts
+++ b/src/tms_service.ts
@@ -220,8 +220,8 @@ export class TMSService extends AbstractEmsService {
   */
   public static transformColorProperties(
     layer: LayerSpecification,
-    color: string,
-    operation: blendMode,
+    color?: string,
+    operation?: blendMode,
     percentage?: number
   ): { property: keyof layerPaintProperty; color: mbColorDefinition | undefined }[] {
     if (['background', 'fill', 'line', 'symbol'].indexOf(layer.type) !== -1 && layer.paint) {
@@ -250,7 +250,10 @@ export class TMSService extends AbstractEmsService {
         const paintColor = paint[type];
         return {
           property: type,
-          color: paintColor ? colorizeColor(paintColor, color, operation, percentage) : paintColor,
+          color:
+            paintColor && color
+              ? colorizeColor(paintColor, color, operation, percentage)
+              : paintColor,
         };
       });
     } else {

--- a/src/tms_service.ts
+++ b/src/tms_service.ts
@@ -222,7 +222,7 @@ export class TMSService extends AbstractEmsService {
     layer: LayerSpecification,
     color: string,
     operation: blendMode,
-    percentage: number
+    percentage?: number
   ): { property: keyof layerPaintProperty; color: mbColorDefinition | undefined }[] {
     if (['background', 'fill', 'line', 'symbol'].indexOf(layer.type) !== -1 && layer.paint) {
       const paint = layer.paint as layerPaintProperty;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,7 +76,7 @@ function transformColor(paintColor: mbColorDefinition, func: Function): mbColorD
       const newColor = transformColor(stop[1], func);
       return [stop[0], newColor];
     });
-    const newPaintColor = { ...paintColor, ...stops };
+    const newPaintColor = Object.assign({}, paintColor, { stops });
     return newPaintColor;
   } else return paintColor;
 }

--- a/test/ems_client_colour.test.ts
+++ b/test/ems_client_colour.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { LayerSpecification } from 'maplibre-gl';
+import { FillLayerSpecification, LayerSpecification } from 'maplibre-gl';
 import { TMSService } from '../src';
 import { mlLayerTypes } from './ems_client_util';
 import chroma from 'chroma-js';
@@ -75,5 +75,40 @@ describe('Transform colours', () => {
         property: 'text-color',
       },
     ]);
+  });
+
+  it('should work with color expressions with stops', () => {
+    const inColor = chroma('#D36086');
+    const fillColors = [chroma('rgba(0,0,0,1)'), chroma('rgba(255,0,0,1)')];
+    const inOp = 'lighten';
+
+    const outColors = fillColors.map((fillColor) => {
+      return chroma.blend(fillColor, inColor, inOp);
+    });
+
+    const transform = TMSService.transformColorProperties;
+
+    const layerWithTextColor = {
+      id: 'layer',
+      type: 'fill',
+      source: '',
+      paint: {
+        'fill-color': {
+          base: 1,
+          stops: fillColors.map((fillColor) => {
+            return [1, chroma2css(fillColor)];
+          }),
+        } as unknown,
+      },
+    } as FillLayerSpecification;
+
+    const { color } = transform(layerWithTextColor, inColor.hex('rgba'), inOp, 0)[0];
+
+    expect(color).toEqual({
+      base: 1,
+      stops: outColors.map((fillColor) => {
+        return [1, chroma2css(fillColor)];
+      }),
+    });
   });
 });

--- a/test/ems_client_colour.test.ts
+++ b/test/ems_client_colour.test.ts
@@ -111,4 +111,30 @@ describe('Transform colours', () => {
       }),
     });
   });
+
+  it('should return the same colors if no input color is specified', () => {
+    const fillColors = ['#ff0000', '#00ff00', '#0000ff'];
+
+    const transform = TMSService.transformColorProperties;
+
+    const fillColorPaint = {
+      base: 1,
+      stops: fillColors.map((fillColor) => {
+        return [1, fillColor];
+      }),
+    };
+
+    const layerWithFillColor = {
+      id: 'layer',
+      type: 'fill',
+      paint: {
+        'fill-color': fillColorPaint,
+      } as unknown,
+    } as FillLayerSpecification;
+
+    const { color, property } = transform(layerWithFillColor)[0];
+
+    expect(property).toEqual('fill-color');
+    expect(color).toEqual(fillColorPaint);
+  });
 });


### PR DESCRIPTION
This is an automatic backport of the following commits to 8.3:
 - #111
 - #112
 - #117
 - #118

Please refer to the [Backport tool documentation](https://github.com/sqren/backport) for additional information