### PR TITLE
Release 8.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [8.4.0] - 2023-01-11
+
+- Default EMS version is 8.4
+- Add types to colorOperationDefaults #123
+- Update dependencies #131 #133 #134 #138
+
 ## [8.3.3] - 2022-05-24
 
 - Make percentage an optional parameter #117

--- a/src/ems_client.ts
+++ b/src/ems_client.ts
@@ -4,7 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
 import _ from 'lodash';
 import { TMSService } from './tms_service';
 import { EMSFormatType, FileLayer } from './file_layer';
@@ -16,7 +15,7 @@ import { toAbsoluteUrl } from './utils';
 import { ParsedUrlQueryInput } from 'querystring';
 import LRUCache from 'lru-cache';
 
-const DEFAULT_EMS_VERSION = '8.3';
+const DEFAULT_EMS_VERSION = '8.4';
 
 type URLMeaningfulParts = {
   auth?: string | null;


### PR DESCRIPTION
Updates the `CHANGELOG` and the `DEFAULT_EMS_VERSION` variable to put the library ready for release.
