### PR TITLE
Bump to 8.5.0

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -2,6 +2,10 @@
   "upstream": "elastic/ems-client",
   "branches": [
     {
+      "name": "8.4",
+      "checked": true
+    },
+    {
       "name": "8.3",
       "checked": true
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [8.5.0] - TBD
+
+- Default EMS version is 8.5
+
+
 ## [8.4.0] - 2023-01-11
 
 - Default EMS version is 8.4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/ems-client",
-  "version": "8.4.0",
+  "version": "8.5.0",
   "description": "JavaScript client library for the Elastic Maps Service",
   "main": "target/node/index.js",
   "browser": "target/web/index.js",

--- a/src/ems_client.ts
+++ b/src/ems_client.ts
@@ -15,7 +15,7 @@ import { toAbsoluteUrl } from './utils';
 import { ParsedUrlQueryInput } from 'querystring';
 import LRUCache from 'lru-cache';
 
-const DEFAULT_EMS_VERSION = '8.4';
+const DEFAULT_EMS_VERSION = '8.5';
 
 type URLMeaningfulParts = {
   auth?: string | null;


### PR DESCRIPTION
Bumps the library to 8.5.0 to host new features for future Elastic Stack releases.
