### PR TITLE
Upgrade to Node 18

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -40,7 +40,7 @@
           set -e
           set +x
 
-          NODE_IMG="node:16"
+          NODE_IMG="node:hydrogen"
 
           docker pull $NODE_IMG
           docker run --rm -i \

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/hydrogen


### PR DESCRIPTION
This PR just ensures that both CI and local environment will run on Node 18 but no changes on the package definition or source code were necessary at this point.

Fixes #143 

Does not seem to be necessary to backport this to `8.4.0` but we can do this later if needed. 

