### PR TITLE
[Buildkite] Setting up CI to test the library on Pull Requests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,3 @@
+steps:
+  - label: ":wave: Greetings"            # Label (with rich emojis https://ela.st/bk-emoji).
+    command: "echo 'My first pipeline!'" # Command to run (evaluated by Bash).

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,18 @@
 steps:
-  - label: ":wave: Greetings"            # Label (with rich emojis https://ela.st/bk-emoji).
-    command: "echo 'My first pipeline!'" # Command to run (evaluated by Bash).
+  - label: ":arrow_double_down: Install yarn"
+    command: "npm install --global yarn"
+
+  - wait: ~
+
+  - label: ":yarn: Install dependencies"
+    command: "yarn install"
+
+  - wait: ~
+
+  - label: ":jest: Test"
+    command: "yarn test"
+
+  - wait: ~
+
+  - label: ":hammer_and_wrench: Build"
+    command: "yarn build"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,9 @@
+agents:
+  image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent:latest"
+
 steps:
   - label: ":hammer_and_wrench: Test and build"
     commands: 
-      - "npm install --global yarn"
       - "yarn install"
       - "yarn test"
       - "yarn build"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,3 +5,6 @@ steps:
       - "yarn install"
       - "yarn test"
       - "yarn build"
+
+notify:
+  - slack: "#maps-ops"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,18 +1,7 @@
 steps:
-  - label: ":arrow_double_down: Install yarn"
-    command: "npm install --global yarn"
-
-  - wait: ~
-
-  - label: ":yarn: Install dependencies"
-    command: "yarn install"
-
-  - wait: ~
-
-  - label: ":jest: Test"
-    command: "yarn test"
-
-  - wait: ~
-
-  - label: ":hammer_and_wrench: Build"
-    command: "yarn build"
+  - label: ":hammer_and_wrench: Test and build"
+    commands: 
+      - "npm install --global yarn"
+      - "yarn install"
+      - "yarn test"
+      - "yarn build"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,6 +5,3 @@ steps:
       - "yarn install"
       - "yarn test"
       - "yarn build"
-
-notify:
-  - slack: "#maps-ops"

--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -1,0 +1,30 @@
+{
+    "jobs": [
+        {
+            "repoOwner": "elastic",
+            "repoName": "ems-client",
+            "enabled": true,
+            "pipeline_slug": "ems-client",
+            "allow_org_users": true,
+            "allowed_repo_permissions": [
+                "admin",
+                "write"
+            ],
+            "allowed_list": [
+                "dependabot"
+            ],
+            "build_on_commit": true,
+            "build_on_comment": true,
+            "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
+            "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
+            "skip_ci_labels": [
+                "skip-ci"
+            ],
+            "skip_ci_on_only_changed": [
+                "\\.md$",
+                "^.ci/.+\\.yml$",
+                "^\\.buildkite/pull_requests\\.json$"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This PR adds the pipeline to run the tests suite and build the library.

~Initially is using the default CI image but I've started a PR to our CI team to get a custom Docker image that will include the `yarn` command so we don't need to install it on every build. We will refine that in a follow-up PR.~

The pipeline uses a custom agent Docker image that includes support for running `yarn` and `gcloud`.


The Pull Requests configuration should give us the ability to trigger builds from comments, but also skip them if the `skip-ci` label is added, or if the changed files are not relevant (markdown files and CI settings). 