### PR TITLE
Update the pipeline definition and document the library

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -26,7 +26,7 @@ spec:
       teams: # Who has access to the pipeline.
         ems: {}
         everyone:
-          access_level: BUILD_AND_READ
+          access_level: READ_ONLY
       provider_settings:
         publish_commit_status: true
       schedules:

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -11,17 +11,25 @@ metadata:
 
 spec:
   type: buildkite-pipeline
+  owner: group:ems
   system: buildkite
   implementation:
     apiVersion: buildkite.elastic.dev/v1
     kind: Pipeline
     metadata:
-      name: ems-client
+      name: EMS Client
+      description: Pipeline to run the EMS Client tests suite on
     spec:
       repository: elastic/ems-client
       pipeline_file: ".buildkite/pipeline.yml"
-      teams:
-        # your-team:
-        #  access_level: MANAGE_BUILD_AND_READ
+      default_branch: master
+      teams: # Who has access to the pipeline.
+        ems: {}
         everyone:
-          access_level: READ_ONLY
+          access_level: BUILD_AND_READ
+      provider_settings:
+        publish_commit_status: true
+      schedules:
+        Weekly build on master branch:
+          cronline: "@weekly"
+          message: "Weekly tests and build"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,4 +1,35 @@
 ---
+# yaml-language-server: $schema=https://json.schemastore.org/catalog-info.json
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ems-client
+  description: JavaScript library to interact with the Elastic Maps Service
+
+  annotations:
+    backstage.io/source-location: url:https://github.com/elastic/ems-client/
+    github.com/project-slug: elastic/ems-client
+    github.com/team-slug: elastic/ems
+    buildkite.com/project-slug: elastic/ems-client
+
+  tags:
+    - nodejs
+    - ems
+    - kibana
+  
+  links:
+    - title: Releases (npm)
+      url: https://www.npmjs.com/@elastic/ems-client
+    - title: Documentation
+      url: https://github.com/elastic/ems-client/blob/master/README.md
+    - title: EMS License
+      url: https://www.elastic.co/elastic-maps-service-terms
+
+spec:
+  type: library
+  owner: group:ems
+  lifecycle: production
+---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: backstage.io/v1alpha1
 kind: Resource


### PR DESCRIPTION
Follow up from #152 

- Include the pipeline definition in the catalog metadata file
- Allow only read for users outside EMS
- Document this library as a `Component` in Backstage ([example](https://github.com/elastic/rally/blob/master/catalog-info.yaml) for reference)
