### PR TITLE
Adds the env var to enable comments on PRs

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -54,6 +54,8 @@ spec:
       repository: elastic/ems-client
       pipeline_file: ".buildkite/pipeline.yml"
       default_branch: master
+      env:
+        ELASTIC_PR_COMMENTS_ENABLED: 'true'
       teams: # Who has access to the pipeline.
         ems: {}
         everyone:


### PR DESCRIPTION
The schema is not validating this setting but I think that's an issue in the schema definition.
