### PR TITLE
Increase buildkite resources

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,7 @@
 agents:
   image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent:latest"
-  memory: "1G"
+  memory: "2G"
+  cpu: '2'
 
 steps:
   - label: ":hammer_and_wrench: Test and build"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,6 @@
 agents:
   image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent:latest"
+  memory: "1G"
 
 steps:
   - label: ":hammer_and_wrench: Test and build"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elastic/ems-client",
   "version": "8.5.0",
-  "description": "JavaScript client library for the Elastic Maps Service - dummy test",
+  "description": "JavaScript client library for the Elastic Maps Service",
   "main": "target/node/index.js",
   "browser": "target/web/index.js",
   "types": "target/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elastic/ems-client",
   "version": "8.5.0",
-  "description": "JavaScript client library for the Elastic Maps Service",
+  "description": "JavaScript client library for the Elastic Maps Service - dummy test",
   "main": "target/node/index.js",
   "browser": "target/web/index.js",
   "types": "target/index.d.ts",


### PR DESCRIPTION
Sets a 1G of RAM to run the tests. This was confirmed locally running this:

```bash
$ docker run --rm \
  -v ${PWD}:/app -w /app \
  --memory=1g --memory-swap=1g --cpus=1 \
  node:18 bash -c \
  "set -eux; yarn install; yarn test; yarn build"
```
