### PR TITLE
[7.17] Update backport config for backporting to 8.4 and 7.17 branches (#169)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,5 +1,16 @@
 {
   "upstream": "elastic/ems-client",
-  "branches": [{ "name": "7.x", "checked": true }, "7.2", "7.6", "7.7", "7.8", "7.9"],
-  "labels": ["backport"]
+  "branches": [
+    {
+      "name": "8.4",
+      "checked": true
+    },
+    {
+      "name": "7.17",
+      "checked": true
+    }
+  ],
+  "labels": [
+    "backport"
+  ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `7.17`:
 - [Update backport config for backporting to 8.4 and 7.17 branches (#169)](https://github.com/elastic/ems-client/pull/169)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)