### PR TITLE
Update the client to understand serverless versioning

### DIFF
--- a/src/ems_client.ts
+++ b/src/ems_client.ts
@@ -10,10 +10,10 @@ import { EMSFormatType, FileLayer } from './file_layer';
 import { FeatureCollection } from 'geojson';
 import { Response } from 'node-fetch';
 
-import coerce from 'semver/functions/coerce';
-import valid from 'semver/functions/valid';
-import major from 'semver/functions/major';
-import minor from 'semver/functions/minor';
+import semverCoerce from 'semver/functions/coerce';
+import semverValid from 'semver/functions/valid';
+import semverMajor from 'semver/functions/major';
+import semverMinor from 'semver/functions/minor';
 
 import { format as formatUrl, parse as parseUrl, UrlObject } from 'url';
 import { toAbsoluteUrl } from './utils';
@@ -396,9 +396,9 @@ export class EMSClient {
   }
 
   private _getEmsVersion(version: string | undefined): string {
-    const semverVersion = valid(coerce(version));
+    const semverVersion = semverValid(semverCoerce(version));
     if (semverVersion) {
-      return `v${major(semverVersion)}.${minor(semverVersion)}`;
+      return `v${semverMajor(semverVersion)}.${semverMinor(semverVersion)}`;
     } else {
       throw new Error(`Invalid version: ${version}`);
     }

--- a/src/ems_client.ts
+++ b/src/ems_client.ts
@@ -9,16 +9,19 @@ import { TMSService } from './tms_service';
 import { EMSFormatType, FileLayer } from './file_layer';
 import { FeatureCollection } from 'geojson';
 import { Response } from 'node-fetch';
-import semver from 'semver';
+
+import coerce from 'semver/functions/coerce';
+import valid from 'semver/functions/valid';
+import major from 'semver/functions/major';
+import minor from 'semver/functions/minor';
+
 import { format as formatUrl, parse as parseUrl, UrlObject } from 'url';
 import { toAbsoluteUrl } from './utils';
 import { ParsedUrlQueryInput } from 'querystring';
 import LRUCache from 'lru-cache';
 
-const DEFAULT_EMS_VERSION = '8.5';
-
 const REST_API_REGEX = /\d{4}-\d{2}-\d{2}/;
-const LATEST_API_URL_PATH = 'latest';
+export const LATEST_API_URL_PATH = 'latest';
 
 type URLMeaningfulParts = {
   auth?: string | null;
@@ -393,10 +396,9 @@ export class EMSClient {
   }
 
   private _getEmsVersion(version: string | undefined): string {
-    const userVersion = semver.valid(semver.coerce(version));
-    const semverVersion = userVersion ? userVersion : semver.coerce(DEFAULT_EMS_VERSION);
+    const semverVersion = valid(coerce(version));
     if (semverVersion) {
-      return `v${semver.major(semverVersion)}.${semver.minor(semverVersion)}`;
+      return `v${major(semverVersion)}.${minor(semverVersion)}`;
     } else {
       throw new Error(`Invalid version: ${version}`);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-export { EMSClient, FileLayerField } from './ems_client';
+export { EMSClient, FileLayerField, LATEST_API_URL_PATH } from './ems_client';
 export { FileLayer } from './file_layer';
 export { TMSService, EmsSprite, EmsSpriteSheet } from './tms_service';
 export { blendMode } from './utils';


### PR DESCRIPTION
Fixes #182
Part of  elastic/kibana#157094

Updates the processing of the versions passed when instantiating the client to understand `YYYY-MM-DD` version schema and update the endpoint URLS accordingly to use the `/latest` permanent link.

Removes the `DEFAULT_EMS_VERSION` constant since the client is not anymore attached to the cadence of the Elastic stack releases, and it is not expected for the EMS Client to have a default version for the services that are consumed.  

Also, following practice in the Kibana codebase limits the usage of `semver` functionality to the functions exposed at `semver/functions`.