### PR TITLE
Upgrade to Node 18

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent:latest"
+  image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent-node18:0.1"
 
 steps:
   - label: ":hammer_and_wrench: Test and build"

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/hydrogen

--- a/package.json
+++ b/package.json
@@ -70,5 +70,8 @@
     "prettier": "^2.0.5",
     "ts-jest": "^26.2.0",
     "typescript": "4.6.3"
+  },
+  "engines": {
+    "node": ">=16 <=18"
   }
 }


### PR DESCRIPTION
Makes the support for Node 18 explicit by:

* Adding the `engines` section to the `package.json` file to make explicit that the library works between 16 and 18
* Adding a `.nvmrc` file for the `lts/hydrogen` release series
* Updates Buildkite job definition to use the Node 18 base image for EMS projects


