### PR TITLE
[7.17] fix: upgrade semver from 7.5.2 to 7.5.4 (#191)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/topojson-specification": "^1.0.1",
     "lodash": "^4.17.15",
     "lru-cache": "^6.0.0",
-    "semver": "7.5.2",
+    "semver": "7.5.4",
     "topojson-client": "^3.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4703,10 +4703,10 @@ semver-regex@^3.1.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@7.5.2:
-  version "7.5.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.2.tgz#5b851e66d1be07c1cdaf37dfc856f543325a2beb"
-  integrity sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==
+semver@7.5.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `7.17`:
 - [fix: upgrade semver from 7.5.2 to 7.5.4 (#191)](https://github.com/elastic/ems-client/pull/191)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)