### PR TITLE
Bump to 8.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [8.5.0] - TBD
+## [8.5.1] TBD
+
+- Update release documentation #194
+
+## [8.5.0] - 2023-08-23
 
 - Migration from Jenkins to Buildkite for automatic testing #145 #147
 - Detached the releases of EMS Client from the services consumed #185

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/ems-client",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "JavaScript client library for the Elastic Maps Service",
   "main": "target/node/index.js",
   "browser": "target/web/index.js",


### PR DESCRIPTION
Bumping after tagging and releasing `8.5.0`.

Upgrading to a patch given there are no big changes here planned. We can always cut a `8.5` branch later if we want a minor release. This also saves maintenance overhead with backports, fixing dependencies and vulnerabilities in multiple branches and so on. 

Happy to discuss this, of course, if we feel better cutting `8.5` now.

