### PR TITLE
Add platform docs as codeowners for OpenAPI files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # OpenAPI spec files
-/docs/openapi          @elastic/platform-docs-team
+/docs/openapi          @elastic/platform-docs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# OpenAPI spec files
+/docs/openapi          @elastic/platform-docs-team


### PR DESCRIPTION
## Summary

**Problem:**
For now, the docs team has to manually sync changes to this repo's OpenAPI spec files to the docs repo used to generate API reference docs.

**Solution:**
Add the Platform docs team as CODEOWNERS to ensure we're notified of any changes (and can then sync them).

**About the error...**
GitHub is complaining that the file contains errors. It doesn't — the Platform docs team exists ([proof](https://github.com/orgs/elastic/teams/platform-docs)), and the members have write access (the _team_ may not).

