### PR TITLE
Add getEmsVersion method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [8.5.1] TBD
 
 - Update release documentation #194
-- Include OpenAPI specification #196
+- Include OpenAPI specification #196 #197
+- Add a new `getEmsVersion` method
 
 ## [8.5.0] - 2023-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Update release documentation #194
 - Include OpenAPI specification #196 #197
-- Add a new `getEmsVersion` method
+- Add a new `getEmsVersion` method #204
 
 ## [8.5.0] - 2023-08-23
 

--- a/src/ems_client.ts
+++ b/src/ems_client.ts
@@ -347,6 +347,10 @@ export class EMSClient {
     return this._cache.get(layerId);
   }
 
+  getEmsVersion(): string {
+    return this._emsVersion;
+  }
+
   getTileApiUrl(): string {
     return this._tileApiUrl;
   }


### PR DESCRIPTION
As discussed [here](https://github.com/elastic/ems-landing-page/pull/680#discussion_r1364148687), a way to get the EMS Version used to initialize the client was needed for EMS Landing Page.

