### PR TITLE
[7.17] Upgrade to Node 20 (#208)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent-node18:0.1"
+  image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent-node20:0.1"
   cpu: "2"
   memory: "2G"
 

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/iron

--- a/package.json
+++ b/package.json
@@ -67,5 +67,8 @@
     "prettier": "^2.0.5",
     "ts-jest": "^26.2.0",
     "typescript": "4.6.3"
+  },
+  "engines": {
+    "node": ">=18 <=20"
   }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `7.17`:
 - [Upgrade to Node 20 (#208)](https://github.com/elastic/ems-client/pull/208)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)