### PR TITLE
Add script to check alignment with Kibana dependencies, update Lodash, downgrade lru-cache

### DIFF
--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -9,6 +9,9 @@ set -eu
 echo "--- :yarn:  Installing dependencies"
 yarn install
 
+echo "--- :gear: Checking dependencies with Kibana"
+node .buildkite/compare_dependencies.js
+
 echo "--- :alembic: Running tests"
 yarn test
 

--- a/.buildkite/compare_dependencies.js
+++ b/.buildkite/compare_dependencies.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/* Script that will check the current package.json dependencies
+against Kibana (using BUILDKITE_BRANCH to determine the branch)
+and exits with a 1 status code if, for any shared dependency, 
+EMS Client is behind */
+
+const fs = require('node:fs');
+const semver = require('semver');
+
+const DEFAULT_BRANCH = 'master';
+const branch = process.env.BUILDKITE_BRANCH || DEFAULT_BRANCH;
+const kibanaPackageUrl = `https://raw.githubusercontent.com/elastic/kibana/${branch}/package.json`;
+
+const processDependency = function (dependency, srcDeps, dstDeps, dstDevDeps) {
+  if (!(dependency in dstDeps) && !(dependency in dstDevDeps)) {
+    return true;
+  }
+  const source = srcDeps[dependency].replace('^', '');
+  const destination = dstDeps[dependency] || dstDevDeps[dependency];
+
+  if (semver.satisfies(source, destination)) {
+    return true;
+  }
+
+  if ( dependency in dstDevDeps){
+    console.log(`⚠  ${dependency}: ${source} vs ${destination}`);
+    return true
+  }
+
+  console.log(`🛑  ${dependency}: ${source} vs ${destination}`);
+  return false;
+};
+
+const main = async function () {
+  const kibanaPackage = await fetch(kibanaPackageUrl);
+  const kibanaPackageJson = await kibanaPackage.json();
+  const kibanaDeps = kibanaPackageJson['dependencies'];
+  const kibanaDevDeps = kibanaPackageJson['devDependencies'];
+
+  const emsClientPackageJson = JSON.parse(fs.readFileSync('package.json'));
+  const emsClientDeps = {
+    ...emsClientPackageJson['dependencies'],
+    ...emsClientPackageJson['devDependencies']
+  };
+
+  console.log(`ems-client@${emsClientPackageJson['version']}`);
+  console.log(`kibana@${kibanaPackageJson['version']}`);
+
+  const results = Object.keys(emsClientDeps).map((dep) =>
+    processDependency(dep, emsClientDeps, kibanaDeps, kibanaDevDeps)
+  );
+
+  process.exit(results.every(r => r) ? 0 : 1);
+};
+
+main()
+  .then(console.log)
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/.buildkite/compare_dependencies.js
+++ b/.buildkite/compare_dependencies.js
@@ -13,8 +13,8 @@ EMS Client is behind */
 const fs = require('node:fs');
 const semver = require('semver');
 
-const DEFAULT_BRANCH = 'master';
-const branch = process.env.BUILDKITE_BRANCH || DEFAULT_BRANCH;
+const DEFAULT_BRANCH = 'main';
+const branch = process.env.KIBANA_BRANCH || DEFAULT_BRANCH;
 const kibanaPackageUrl = `https://raw.githubusercontent.com/elastic/kibana/${branch}/package.json`;
 
 const processDependency = function (dependency, srcDeps, dstDeps, dstDevDeps) {

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,3 +6,5 @@ agents:
 steps:
   - label: ":hammer_and_wrench: Test and build"
     command: ".buildkite/build.sh"
+    env:
+      KIBANA_BRANCH: "main"

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,7 +8,7 @@ export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   {
-    ignores: ["target","*.config.js"]
+    ignores: ["target","*.config.js",".buildkite"]
   },
   {
     files: ['**/*.{ts,tsx,mts,cts}'],

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "@types/topojson-client": "^3.1.4",
     "@types/topojson-specification": "^1.0.5",
     "chroma-js": "^2.1.0",
-    "lodash": "^4.17.15",
-    "lru-cache": "7.18.3",
-    "semver": "7.6.2",
+    "lodash": "^4.17.21",
+    "lru-cache": "^4.1.5",
+    "semver": "^7.6.2",
     "topojson-client": "^3.1.0"
   },
   "devDependencies": {
@@ -51,7 +51,7 @@
     "@types/eslint__js": "^8.42.3",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.14.150",
-    "@types/lru-cache": "^7.10.10",
+    "@types/lru-cache": "^5.1.0",
     "@types/node": "^20.12.13",
     "@types/node-fetch": "^2.5.7",
     "@types/semver": "^7.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1771,12 +1771,10 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.6.tgz#193ced6a40c8006cfc1ca3f4553444fb38f0e543"
   integrity sha512-OpXEVoCKSS3lQqjx9GGGOapBeuW5eUboYHRlHP9urXPX25IKZ6AnP5ZRxtVf63iieUbsHxLn8NQ5Nlftc6yzAA==
 
-"@types/lru-cache@^7.10.10":
-  version "7.10.10"
-  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-7.10.10.tgz#3fa937c35ff4b3f6753d5737915c9bf8e693a713"
-  integrity sha512-nEpVRPWW9EBmx2SCfNn3ClYxPL7IktPX12HhIoSc/H5mMjdeW3+YsXIpseLQ2xF35+OcpwKQbEUw5VtqE4PDNA==
-  dependencies:
-    lru-cache "*"
+"@types/lru-cache@^5.1.0":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.1.tgz#c48c2e27b65d2a153b19bfc1a317e30872e01eef"
+  integrity sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==
 
 "@types/mapbox__point-geometry@*":
   version "0.1.2"
@@ -3577,20 +3575,18 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@^4.17.15:
+lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-lru-cache@*:
-  version "10.3.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.3.0.tgz#4a4aaf10c84658ab70f79a85a9a3f1e1fb11196b"
-  integrity sha512-CQl19J/g+Hbjbv4Y3mFNNXFEL/5t/KCg8POCuUqd4rMKjGG+j1ybER83hxV58zL+dFI1PTkt3GNFSHRt+d8qEQ==
-
-lru-cache@7.18.3:
-  version "7.18.3"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
-  integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
+lru-cache@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
 
 lru-cache@^5.1.1:
   version "5.1.1"
@@ -3934,6 +3930,11 @@ protocol-buffers-schema@^3.3.1:
   resolved "https://registry.yarnpkg.com/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz#77bc75a48b2ff142c1ad5b5b90c94cd0fa2efd03"
   integrity sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==
 
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+  integrity sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==
+
 punycode@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
@@ -4069,11 +4070,6 @@ rw@^1.3.3:
   resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
   integrity sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==
 
-semver@7.6.2, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0:
-  version "7.6.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.2.tgz#1e3b34759f896e8f14d6134732ce798aeb0c6e13"
-  integrity sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==
-
 semver@^5.6.0:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
@@ -4083,6 +4079,11 @@ semver@^6.0.0, semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.2:
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.2.tgz#1e3b34759f896e8f14d6134732ce798aeb0c6e13"
+  integrity sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==
 
 set-value@^2.0.1:
   version "2.0.1"
@@ -4511,6 +4512,11 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+  integrity sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==
 
 yallist@^3.0.2:
   version "3.1.1"


### PR DESCRIPTION
To help keep dependencies in sync with Kibana, adding a new script to our CI that checks that every dependency in EMS Client satisfies the version in Kibana.

The script and CI build will fail if there's any dependency not satisfying the version for Kibana and will only report those that don't satisfy Kibana's `devDependencies` list in the `package.json`.

The [second build](https://buildkite.com/elastic/ems-client/builds/331) of this PR shows how `lodash` and `lru-cache` are not aligned with Kibana `main` and failed. After upgrading them in 334d00c the script now only reports packages not aligned in Kibana `devDependencies` list, which should be OK to ignore for this library.

>[!note]
> When backporting this PR additional work may be required
> to align with the `7.17` branch of Kibana.
