### PR TITLE
[7.17] Add script to check alignment with Kibana dependencies, update Lodash, downgrade lru-cache (#242)

### DIFF
--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -9,6 +9,9 @@ set -eu
 echo "--- :yarn:  Installing dependencies"
 yarn install
 
+echo "--- :gear: Checking dependencies with Kibana"
+node .buildkite/compare_dependencies.js
+
 echo "--- :alembic: Running tests"
 yarn test
 

--- a/.buildkite/compare_dependencies.js
+++ b/.buildkite/compare_dependencies.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/* Script that will check the current package.json dependencies
+against Kibana (using BUILDKITE_BRANCH to determine the branch)
+and exits with a 1 status code if, for any shared dependency, 
+EMS Client is behind */
+
+const fs = require('node:fs');
+const semver = require('semver');
+
+const DEFAULT_BRANCH = 'main';
+const branch = process.env.KIBANA_BRANCH || DEFAULT_BRANCH;
+const kibanaPackageUrl = `https://raw.githubusercontent.com/elastic/kibana/${branch}/package.json`;
+
+const processDependency = function (dependency, srcDeps, dstDeps, dstDevDeps) {
+  if (!(dependency in dstDeps) && !(dependency in dstDevDeps)) {
+    return true;
+  }
+  const source = srcDeps[dependency].replace('^', '');
+  const destination = dstDeps[dependency] || dstDevDeps[dependency];
+
+  if (semver.satisfies(source, destination)) {
+    return true;
+  }
+
+  if ( dependency in dstDevDeps){
+    console.log(`⚠  ${dependency}: ${source} vs ${destination}`);
+    return true
+  }
+
+  console.log(`🛑  ${dependency}: ${source} vs ${destination}`);
+  return false;
+};
+
+const main = async function () {
+  const kibanaPackage = await fetch(kibanaPackageUrl);
+  const kibanaPackageJson = await kibanaPackage.json();
+  const kibanaDeps = kibanaPackageJson['dependencies'];
+  const kibanaDevDeps = kibanaPackageJson['devDependencies'];
+
+  const emsClientPackageJson = JSON.parse(fs.readFileSync('package.json'));
+  const emsClientDeps = {
+    ...emsClientPackageJson['dependencies'],
+    ...emsClientPackageJson['devDependencies']
+  };
+
+  console.log(`ems-client@${emsClientPackageJson['version']}`);
+  console.log(`kibana@${kibanaPackageJson['version']}`);
+
+  const results = Object.keys(emsClientDeps).map((dep) =>
+    processDependency(dep, emsClientDeps, kibanaDeps, kibanaDevDeps)
+  );
+
+  process.exit(results.every(r => r) ? 0 : 1);
+};
+
+main()
+  .then(console.log)
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,3 +6,5 @@ agents:
 steps:
   - label: ":hammer_and_wrench: Test and build"
     command: ".buildkite/build.sh"
+    env:
+      KIBANA_BRANCH: "main"

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "@types/lru-cache": "^5.1.0",
     "@types/topojson-client": "^3.1.4",
     "@types/topojson-specification": "^1.0.5",
-    "lodash": "^4.17.15",
-    "lru-cache": "^6.0.0",
+    "lodash": "^4.17.21",
+    "lru-cache": "^4.1.5",
     "semver": "7.6.2",
     "topojson-client": "^3.1.0"
   },
@@ -63,7 +63,7 @@
     "eslint-plugin-prettier": "^3.1.3",
     "husky": "^4.2.5",
     "jest": "^26.4.0",
-    "node-fetch": "^2.6.1",
+    "node-fetch": "^2.6.7",
     "prettier": "^2.0.5",
     "ts-jest": "^26.2.0",
     "typescript": "4.6.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4026,10 +4026,18 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@4.x, lodash@^4.17.15, lodash@^4.7.0:
+lodash@4.x, lodash@^4.17.15, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+lru-cache@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
 
 lru-cache@^5.1.1:
   version "5.1.1"
@@ -4202,7 +4210,7 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-fetch@^2.6.1:
+node-fetch@^2.6.7:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
@@ -4540,6 +4548,11 @@ prompts@^2.0.1:
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
+
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+  integrity sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==
 
 psl@^1.1.33:
   version "1.8.0"
@@ -5512,6 +5525,11 @@ y18n@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
   integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+  integrity sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==
 
 yallist@^3.0.2:
   version "3.1.1"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `7.17`:
 - [Add script to check alignment with Kibana dependencies, update Lodash, downgrade lru-cache (#242)](https://github.com/elastic/ems-client/pull/242)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)