### PR TITLE
[7.17] fix: upgrade chroma-js from 2.4.2 to 2.6.0 (#252)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/lru-cache": "^5.1.0",
     "@types/topojson-client": "^3.1.4",
     "@types/topojson-specification": "^1.0.5",
+    "chroma-js": "^2.6.0",
     "lodash": "^4.17.21",
     "lru-cache": "^4.1.5",
     "semver": "7.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2279,6 +2279,11 @@ chokidar@^3.4.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
+chroma-js@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/chroma-js/-/chroma-js-2.6.0.tgz#578743dd359698a75067a19fa5571dec54d0b70b"
+  integrity sha512-BLHvCB9s8Z1EV4ethr6xnkl/P2YRFOGqfgvuMG/MyCbZPrTA+NeiByY6XvgF0zP4/2deU2CXnWyMa3zu1LqQ3A==
+
 ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `7.17`:
 - [fix: upgrade chroma-js from 2.4.2 to 2.6.0 (#252)](https://github.com/elastic/ems-client/pull/252)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)