### PR TITLE
[7.17] chore(deps): update dependency typescript to v5.5.4 (#260)

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "node-fetch": "2.7.0",
     "prettier": "2.8.8",
     "ts-jest": "26.5.0",
-    "typescript": "4.6.3"
+    "typescript": "5.5.4"
   },
   "engines": {
     "node": ">=18 <=20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5513,10 +5513,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@4.6.3:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
-  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
+typescript@5.5.4:
+  version "5.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.4.tgz#d9852d6c82bad2d2eda4fd74a5762a8f5909e9ba"
+  integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==
 
 undici-types@~5.26.4:
   version "5.26.5"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `7.17`:
 - [chore(deps): update dependency typescript to v5.5.4 (#260)](https://github.com/elastic/ems-client/pull/260)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)