### PR TITLE
[7.17] chore(deps): update docker.elastic.co/ci-agent-images/ems/buildkite-agent-node20 docker tag to v0.5 (#297)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent-node20:0.1"
+  image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent-node20:0.5@sha256:01d63c1c1e9895e410a8b50c0eb0ce8e986c354085a11ed1d00355a12935ac5e"
   cpu: "2"
   memory: "2G"
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `7.17`:
 - [chore(deps): update docker.elastic.co/ci-agent-images/ems/buildkite-agent-node20 docker tag to v0.5 (#297)](https://github.com/elastic/ems-client/pull/297)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)