### PR TITLE
[7.17] chore(deps): update dependency @types/node to v20.16.2 (#306)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@types/jest": "29.5.12",
     "@types/lodash": "4.17.7",
     "@types/lru-cache": "5.1.1",
-    "@types/node": "20.16.1",
+    "@types/node": "20.16.2",
     "@types/node-fetch": "2.6.11",
     "@types/semver": "7.5.8",
     "@types/topojson-specification": "1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1882,10 +1882,10 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@20.16.1":
-  version "20.16.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.16.1.tgz#0b44b15271d0e2191ca68faf1fbe506e06aed732"
-  integrity sha512-zJDo7wEadFtSyNz5QITDfRcrhqDvQI1xQNQ0VoizPjM/dVAODqqIUWbJPkvsxmTI0MYRGRikcdjMPhOssnPejQ==
+"@types/node@20.16.2":
+  version "20.16.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.16.2.tgz#9e388f503a5af306e8c63319334887390966a11e"
+  integrity sha512-91s/n4qUPV/wg8eE9KHYW1kouTfDk2FPGjXbBMfRWP/2vg1rCXNQL1OCabwGs0XSdukuK+MwCDXE30QpSeMUhQ==
   dependencies:
     undici-types "~6.19.2"
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `7.17`:
 - [chore(deps): update dependency @types/node to v20.16.2 (#306)](https://github.com/elastic/ems-client/pull/306)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)