### PR TITLE
[7.17] chore(deps): update dependency @types/node to v20.16.5 (#317)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@types/jest": "29.5.12",
     "@types/lodash": "4.17.7",
     "@types/lru-cache": "5.1.1",
-    "@types/node": "20.16.4",
+    "@types/node": "20.16.5",
     "@types/node-fetch": "2.6.11",
     "@types/semver": "7.5.8",
     "@types/topojson-specification": "1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1882,10 +1882,10 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@20.16.4":
-  version "20.16.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.16.4.tgz#2e3d9e1da4761a0fdb725d9497df4bb091e9c2f1"
-  integrity sha512-ioyQ1zK9aGEomJ45zz8S8IdzElyxhvP1RVWnPrXDf6wFaUb+kk1tEcVVJkF7RPGM0VWI7cp5U57oCPIn5iN1qg==
+"@types/node@20.16.5":
+  version "20.16.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.16.5.tgz#d43c7f973b32ffdf9aa7bd4f80e1072310fd7a53"
+  integrity sha512-VwYCweNo3ERajwy0IUlqqcyZ8/A7Zwa9ZP3MnENWcB11AejO+tLy3pu850goUW2FC/IJMdZUfKpX/yxL1gymCA==
   dependencies:
     undici-types "~6.19.2"
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `7.17`:
 - [chore(deps): update dependency @types/node to v20.16.5 (#317)](https://github.com/elastic/ems-client/pull/317)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)