### PR TITLE
[7.17] chore(deps): update dependency @types/jest to v29.5.13 (#325)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@babel/preset-typescript": "7.24.7",
     "@eslint/js": "9.10.0",
     "@types/eslint__js": "8.42.3",
-    "@types/jest": "29.5.12",
+    "@types/jest": "29.5.13",
     "@types/lodash": "4.17.7",
     "@types/lru-cache": "5.1.1",
     "@types/node": "20.16.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1851,10 +1851,10 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@29.5.12":
-  version "29.5.12"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.12.tgz#7f7dc6eb4cf246d2474ed78744b05d06ce025544"
-  integrity sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==
+"@types/jest@29.5.13":
+  version "29.5.13"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.13.tgz#8bc571659f401e6a719a7bf0dbcb8b78c71a8adc"
+  integrity sha512-wd+MVEZCHt23V0/L642O5APvspWply/rGY5BcW4SUETo2UzPU3Z26qr8jC2qxpimI2jjx9h7+2cj2FwIr01bXg==
   dependencies:
     expect "^29.0.0"
     pretty-format "^29.0.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `7.17`:
 - [chore(deps): update dependency @types/jest to v29.5.13 (#325)](https://github.com/elastic/ems-client/pull/325)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)