### PR TITLE
[7.17] fix(deps): update dependency @types/topojson-client to v3.1.5 (#329)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@types/geojson": "7946.0.14",
-    "@types/topojson-client": "3.1.4",
+    "@types/topojson-client": "3.1.5",
     "lodash": "4.17.21",
     "lru-cache": "4.1.5",
     "node-fetch": "2.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1906,10 +1906,10 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
-"@types/topojson-client@3.1.4":
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/@types/topojson-client/-/topojson-client-3.1.4.tgz#81b83f9ecd6542dc5c3df21967f992e3fe192c33"
-  integrity sha512-Ntf3ZSetMYy7z3PrVCvcqmdRoVhgKA9UKN0ZuuZf8Ts2kcyL4qK34IXBs6qO5fem62EK4k03PtkJPVoroVu4/w==
+"@types/topojson-client@3.1.5":
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/@types/topojson-client/-/topojson-client-3.1.5.tgz#3fdbcd52161db8747a071b1d0f635ac700cf599d"
+  integrity sha512-C79rySTyPxnQNNguTZNI1Ct4D7IXgvyAs3p9HPecnl6mNrJ5+UhvGNYcZfpROYV2lMHI48kJPxwR+F9C6c7nmw==
   dependencies:
     "@types/geojson" "*"
     "@types/topojson-specification" "*"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `7.17`:
 - [fix(deps): update dependency @types/topojson-client to v3.1.5 (#329)](https://github.com/elastic/ems-client/pull/329)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)