### PR TITLE
[7.17] chore(deps): pin dependency @eslint/core to 0.6.0 (#344)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/plugin-proposal-class-properties": "7.18.6",
     "@babel/preset-env": "7.25.4",
     "@babel/preset-typescript": "7.24.7",
-    "@eslint/core": "^0.6.0",
+    "@eslint/core": "0.6.0",
     "@eslint/js": "9.11.1",
     "@types/eslint__js": "8.42.3",
     "@types/jest": "29.5.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1430,7 +1430,7 @@
     debug "^4.3.1"
     minimatch "^3.1.2"
 
-"@eslint/core@^0.6.0":
+"@eslint/core@0.6.0", "@eslint/core@^0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@eslint/core/-/core-0.6.0.tgz#9930b5ba24c406d67a1760e94cdbac616a6eb674"
   integrity sha512-8I2Q8ykA4J0x0o7cg67FPVnehcqWTBehu/lmY+bolPFHGjh49YzGBMXTvpqVgEbBdvNCSxj6iFgiIyHzf03lzg==


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `7.17`:
 - [chore(deps): pin dependency @eslint/core to 0.6.0 (#344)](https://github.com/elastic/ems-client/pull/344)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)