### PR TITLE
[7.17] chore(deps): update dependency @types/node to v20.16.10 (#345)

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@types/jest": "29.5.13",
     "@types/lodash": "4.17.9",
     "@types/lru-cache": "5.1.1",
-    "@types/node": "20.16.9",
+    "@types/node": "20.16.10",
     "@types/node-fetch": "2.6.11",
     "@types/semver": "7.5.8",
     "@types/topojson-specification": "1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1899,10 +1899,10 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@20.16.9":
-  version "20.16.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.16.9.tgz#1217c6cc77c4f3aaf4a6c76fb56b790e81e48120"
-  integrity sha512-rkvIVJxsOfBejxK7I0FO5sa2WxFmJCzoDwcd88+fq/CUfynNywTo/1/T6hyFz22CyztsnLS9nVlHOnTI36RH5w==
+"@types/node@20.16.10":
+  version "20.16.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.16.10.tgz#0cc3fdd3daf114a4776f54ba19726a01c907ef71"
+  integrity sha512-vQUKgWTjEIRFCvK6CyriPH3MZYiYlNy0fKiEYHWbcoWLEgs4opurGGKlebrTLqdSMIbXImH6XExNiIyNUv3WpA==
   dependencies:
     undici-types "~6.19.2"
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `7.17`:
 - [chore(deps): update dependency @types/node to v20.16.10 (#345)](https://github.com/elastic/ems-client/pull/345)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)