### PR TITLE
[7.17] chore(deps): update dependency @types/lodash to v4.17.12 (#377)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@eslint/js": "9.12.0",
     "@types/eslint__js": "8.42.3",
     "@types/jest": "29.5.13",
-    "@types/lodash": "4.17.11",
+    "@types/lodash": "4.17.12",
     "@types/lru-cache": "5.1.1",
     "@types/node": "20.16.12",
     "@types/node-fetch": "2.6.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1840,10 +1840,10 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
-"@types/lodash@4.17.11":
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.11.tgz#8d01705ee14865015a0520e80b7ce95f3c2f7060"
-  integrity sha512-jzqWo/uQP/iqeGGTjhgFp2yaCrCYTauASQcpdzESNCkHjSprBJVcZP9KG9aQ0q+xcsXiKd/iuw/4dLjS3Odc7Q==
+"@types/lodash@4.17.12":
+  version "4.17.12"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.12.tgz#25d71312bf66512105d71e55d42e22c36bcfc689"
+  integrity sha512-sviUmCE8AYdaF/KIHLDJBQgeYzPBI0vf/17NaYehBJfYD1j6/L95Slh07NlyK2iNyBNaEkb3En2jRt+a8y3xZQ==
 
 "@types/lru-cache@5.1.1":
   version "5.1.1"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `7.17`:
 - [chore(deps): update dependency @types/lodash to v4.17.12 (#377)](https://github.com/elastic/ems-client/pull/377)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)