### PR TITLE
[7.17] chore(deps): update dependency @eslint/core to v0.7.0 (#379)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/plugin-proposal-class-properties": "7.18.6",
     "@babel/preset-env": "7.25.8",
     "@babel/preset-typescript": "7.25.7",
-    "@eslint/core": "0.6.0",
+    "@eslint/core": "0.7.0",
     "@eslint/js": "9.12.0",
     "@types/eslint__js": "8.42.3",
     "@types/jest": "29.5.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1378,7 +1378,12 @@
     debug "^4.3.1"
     minimatch "^3.1.2"
 
-"@eslint/core@0.6.0", "@eslint/core@^0.6.0":
+"@eslint/core@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@eslint/core/-/core-0.7.0.tgz#a1bb4b6a4e742a5ff1894b7ee76fbf884ec72bd3"
+  integrity sha512-xp5Jirz5DyPYlPiKat8jaq0EmYvDXKKpzTbxXMpT9eqlRJkRKIz9AGMdlvYjih+im+QlhWrpvVjl8IPC/lHlUw==
+
+"@eslint/core@^0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@eslint/core/-/core-0.6.0.tgz#9930b5ba24c406d67a1760e94cdbac616a6eb674"
   integrity sha512-8I2Q8ykA4J0x0o7cg67FPVnehcqWTBehu/lmY+bolPFHGjh49YzGBMXTvpqVgEbBdvNCSxj6iFgiIyHzf03lzg==


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `7.17`:
 - [chore(deps): update dependency @eslint/core to v0.7.0 (#379)](https://github.com/elastic/ems-client/pull/379)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)