### PR TITLE
[7.17] chore(deps): update dependency @types/jest to v29.5.14 (#390)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@eslint/core": "0.7.0",
     "@eslint/js": "9.13.0",
     "@types/eslint__js": "8.42.3",
-    "@types/jest": "29.5.13",
+    "@types/jest": "29.5.14",
     "@types/lodash": "4.17.12",
     "@types/lru-cache": "5.1.1",
     "@types/node": "20.16.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1827,10 +1827,10 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@29.5.13":
-  version "29.5.13"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.13.tgz#8bc571659f401e6a719a7bf0dbcb8b78c71a8adc"
-  integrity sha512-wd+MVEZCHt23V0/L642O5APvspWply/rGY5BcW4SUETo2UzPU3Z26qr8jC2qxpimI2jjx9h7+2cj2FwIr01bXg==
+"@types/jest@29.5.14":
+  version "29.5.14"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.14.tgz#2b910912fa1d6856cadcd0c1f95af7df1d6049e5"
+  integrity sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==
   dependencies:
     expect "^29.0.0"
     pretty-format "^29.0.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `7.17`:
 - [chore(deps): update dependency @types/jest to v29.5.14 (#390)](https://github.com/elastic/ems-client/pull/390)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)