### PR TITLE
Remove node-fetch imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "lodash": "^4.17.21",
     "lru-cache": "^4.1.5",
     "maplibre-gl": "3.1.0",
-    "node-fetch": "2.7.0",
     "semver": "^7.6.3",
     "topojson-client": "^3.1.0"
   },
@@ -67,6 +66,7 @@
     "globals": "15.14.0",
     "husky": "9.1.7",
     "jest": "29.7.0",
+    "node-fetch": "2.7.0",
     "prettier": "3.4.2",
     "ts-jest": "29.2.5",
     "typescript": "5.7.2",

--- a/src/ems_client.ts
+++ b/src/ems_client.ts
@@ -8,7 +8,6 @@ import _ from 'lodash';
 import { TMSService } from './tms_service';
 import { EMSFormatType, FileLayer } from './file_layer';
 import { FeatureCollection } from 'geojson';
-import { Response } from 'node-fetch';
 
 import semverCoerce from 'semver/functions/coerce';
 import semverValid from 'semver/functions/valid';
@@ -19,7 +18,6 @@ import { format as formatUrl, parse as parseUrl, UrlObject } from 'url';
 import { toAbsoluteUrl } from './utils';
 import { ParsedUrlQueryInput } from 'querystring';
 import LRUCache from 'lru-cache';
-import { RequestInfo } from 'node-fetch';
 
 const REST_API_REGEX = /\d{4}-\d{2}-\d{2}/;
 export const LATEST_API_URL_PATH = 'latest';

--- a/test/ems_client_util.ts
+++ b/test/ems_client_util.ts
@@ -6,7 +6,6 @@
  */
 
 import { EMSClient } from '../src';
-import fetch from 'node-fetch';
 
 import EMS_CATALOGUE from './ems_mocks/sample_manifest.json';
 import EMS_FILES from './ems_mocks/sample_files.json';


### PR DESCRIPTION
Removing imports for `Response` and `RequestInfo` types from `node-fetch` and moving the library to the `devDependencies` block. After testing the `7.17.4` new release in Kibana 7.17, these `node-fetch` references where breaking in frontend code both in Vega and Maps application. Going entirely in our code to reference the native types should fix this. I'll do a new release `8.6.1` and `7.17.5` after this fix so we can move on.

