### PR TITLE
[7.17] [skip-ci] fix backport setup (#520)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,10 +1,17 @@
 {
   "repoOwner": "elastic",
-  "repoName": "ems-file-service",
-  "targetBranches": ["7.17"],
+  "repoName": "ems-client",
+  "targetBranchChoices": [
+    "master",
+    "7.17"
+  ],
+  "branchLabelMapping": {
+    "^v8.\\d+.\\d+$": "master",
+    "^v7.\\d+.\\d+$": "v7.17"
+  },
   "targetPRLabels": ["backport"],
   "commitConflicts": true,
-  "autoMerge": true,
+  "autoMerge": false,
   "autoMergeMethod": "squash",
   "fork": false
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `7.17`:
 - [[skip-ci] fix backport setup (#520)](https://github.com/elastic/ems-client/pull/520)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)