### PR TITLE
Bump to 8.6.2 and downgrade chroma-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/ems-client",
-  "version": "8.6.1",
+  "version": "8.6.2",
   "description": "JavaScript client library for the Elastic Maps Service",
   "main": "target/node/index.js",
   "browser": "target/web/index.js",
@@ -33,7 +33,7 @@
   "dependencies": {
     "@types/geojson": "7946.0.15",
     "@types/topojson-client": "3.1.5",
-    "chroma-js": "^2.6.0",
+    "chroma-js": "2.4.2",
     "lodash": "^4.17.21",
     "lru-cache": "^4.1.5",
     "maplibre-gl": "3.1.0",

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "labels": [
     "dependencies",
     "v7.17.5",
-    "v8.6.1"
+    "v8.6.2"
   ],
   "packageRules": [
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2524,10 +2524,10 @@ chokidar@^3.6.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
-chroma-js@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/chroma-js/-/chroma-js-2.6.0.tgz#578743dd359698a75067a19fa5571dec54d0b70b"
-  integrity sha512-BLHvCB9s8Z1EV4ethr6xnkl/P2YRFOGqfgvuMG/MyCbZPrTA+NeiByY6XvgF0zP4/2deU2CXnWyMa3zu1LqQ3A==
+chroma-js@2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chroma-js/-/chroma-js-2.4.2.tgz#dffc214ed0c11fa8eefca2c36651d8e57cbfb2b0"
+  integrity sha512-U9eDw6+wt7V8z5NncY2jJfZa+hUH8XEj8FQHgFJTrUFnJfXYf4Ml4adI2vXZOjqRDpFWtYVWypDfZwnJ+HIR4A==
 
 ci-info@^3.2.0:
   version "3.9.0"


### PR DESCRIPTION
* Bumps `package.json` and `renovate.json` to  `8.6.2`
* Downgrades `chroma-js` to match Kibana version. The library upgraded to use ESM modules and that is clashing with Jest tests, so aligning with the version used by Charts and EUI libraries.

