### PR TITLE
[7.17] chore(deps): update dependency @types/lodash to v4.17.19 (#835)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@eslint/js": "9.29.0",
     "@types/eslint__js": "8.42.3",
     "@types/jest": "30.0.0",
-    "@types/lodash": "4.17.18",
+    "@types/lodash": "4.17.19",
     "@types/lru-cache": "7.10.10",
     "@types/node": "22.15.32",
     "@types/semver": "7.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1503,10 +1503,10 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
-"@types/lodash@4.17.18":
-  version "4.17.18"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.18.tgz#4710e7db5b3857103764bf7b7b666414e6141baf"
-  integrity sha512-KJ65INaxqxmU6EoCiJmRPZC9H9RVWCRd349tXM2M3O5NA7cY6YL7c0bHAHQ93NOfTObEQ004kd2QVHs/r0+m4g==
+"@types/lodash@4.17.19":
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.19.tgz#de18c90b7891f00fed7c1273495a2f851efd99c4"
+  integrity sha512-NYqRyg/hIQrYPT9lbOeYc3kIRabJDn/k4qQHIXUpx88CBDww2fD15Sg5kbXlW86zm2XEW4g0QxkTI3/Kfkc7xQ==
 
 "@types/lru-cache@7.10.10":
   version "7.10.10"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `7.17`:
 - [chore(deps): update dependency @types/lodash to v4.17.19 (#835)](https://github.com/elastic/ems-client/pull/835)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)