### PR TITLE
[ci] Set up renovate per branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,10 +5,9 @@
   "extends": [
     "github>elastic/renovate-config"
   ],
+  "baseBranches": ["master", "7.17"],
   "labels": [
-    "dependencies",
-    "v7.17.7",
-    "v8.6.4"
+    "dependencies"
   ],
   "packageRules": [
     {
@@ -18,6 +17,16 @@
     {
       "matchDepTypes": ["devDependencies"],
       "automerge": true
+    },
+    {
+      "description": "Master branch specific rules",
+      "matchBaseBranches": ["master"],
+      "labels": ["dependencies", "v8.6.4"]
+    },
+    {
+      "description": "7.17 branch specific rules",
+      "matchBaseBranches": ["7.17"],
+      "labels": ["dependencies", "v7.17.7"]
     }
   ]
 }


### PR DESCRIPTION
Updates `renovate.json` to treat `master` and `7.17` independently. This has several benefits:

* Avoid backport for dependencies, which sometimes create conflicts that require manual fix
* Keeps dependencies for both branches separated, so for example `7.17` does not depend from `maplibre-gl` or `chroma-js` and with this approach we don't need to care about those PRs not having to be backported.

