### PR TITLE
[7.17] [skip-ci] Update renovate deprecated property (#1050)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   "extends": [
     "github>elastic/renovate-config"
   ],
-  "baseBranches": ["master", "7.17"],
+  "baseBranchPatterns": ["master", "7.17"],
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `7.17`:
 - [[skip-ci] Update renovate deprecated property (#1050)](https://github.com/elastic/ems-client/pull/1050)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)