### PR TITLE
Align chroma-js with Kibana

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@types/geojson": "7946.0.16",
     "@types/topojson-client": "3.1.5",
-    "chroma-js": "2.6.0",
+    "chroma-js": "2.4.2",
     "lodash": "^4.17.21",
     "lru-cache": "11.2.4",
     "maplibre-gl": "5.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2968,10 +2968,10 @@ chokidar@^3.6.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
-chroma-js@2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/chroma-js/-/chroma-js-2.6.0.tgz#578743dd359698a75067a19fa5571dec54d0b70b"
-  integrity sha512-BLHvCB9s8Z1EV4ethr6xnkl/P2YRFOGqfgvuMG/MyCbZPrTA+NeiByY6XvgF0zP4/2deU2CXnWyMa3zu1LqQ3A==
+chroma-js@2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chroma-js/-/chroma-js-2.4.2.tgz#dffc214ed0c11fa8eefca2c36651d8e57cbfb2b0"
+  integrity sha512-U9eDw6+wt7V8z5NncY2jJfZa+hUH8XEj8FQHgFJTrUFnJfXYf4Ml4adI2vXZOjqRDpFWtYVWypDfZwnJ+HIR4A==
 
 ci-info@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
Our CI is red because the recent change in Kibana https://github.com/elastic/kibana/pull/244556 pinned `chroma-js` to a version that is older than ours, hence downgrading our library to align with this PR.
