### PR TITLE
Deprecate 7.17 branch

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -2,12 +2,10 @@
   "repoOwner": "elastic",
   "repoName": "ems-client",
   "targetBranchChoices": [
-    "master",
-    "7.17"
+    "master"
   ],
   "branchLabelMapping": {
-    "^v8.\\d+.\\d+$": "master",
-    "^v7.\\d+.\\d+$": "7.17"
+    "^v8.\\d+.\\d+$": "master"
   },
   "targetPRLabels": ["backport"],
   "commitConflicts": true,

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   "extends": [
     "github>elastic/renovate-config"
   ],
-  "baseBranches": ["master", "7.17"],
+  "baseBranches": ["master"],
   "labels": [
     "dependencies"
   ],
@@ -22,11 +22,6 @@
       "description": "Master branch specific rules",
       "matchBaseBranches": ["master"],
       "labels": ["dependencies", "v8.6.4"]
-    },
-    {
-      "description": "7.17 branch specific rules",
-      "matchBaseBranches": ["7.17"],
-      "labels": ["dependencies", "v7.17.7"]
     }
   ]
 }


### PR DESCRIPTION
Related to https://github.com/elastic/ems-landing-page/pull/2942

Removing references to `7.17` in our backport and renovate configurations, as this branch is getting officially deprecated.