### PR TITLE
Add npm Trusted Publisher workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - run: yarn install --frozen-lockfile
+
+      - run: yarn build
+
+      - run: npm publish --provenance --access public

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,16 +9,14 @@
 
 If you have access to make releases, the process is as follows:
 
-1. Be sure you have checked out the `master` or released branch and have pulled latest changes
+1. Be sure you have checked out the `master` branch and have pulled latest changes
 1. Update the version in `package.json` accordingly.
 1. Update the CHANGELOG.md
 1. Commit changes with message "bump to x.y.z" where x.y.z is the version in package.json
-1. Tag the commit with `git tag vx.y.x`, for example `git tag v7.2.1`
+1. Tag the commit with `git tag vx.y.z`, for example `git tag v7.2.1`
 1. Push commits and tags upstream with `git push upstream master && git push upstream --tags` (and optionally to your own fork as well)
-1. Update the latest major branch on upstream with `git push upstream <major_branch>`
-1. Build the targets with `yarn build`
-1. Publish to npm with `npm publish --access public`
-1. If necessary, push the new branch upstream and create/archive Snyk targets
+1. The [publish workflow](.github/workflows/publish.yml) will automatically build and publish to npm via [npm Trusted Publishers](https://docs.npmjs.com/trusted-publishers) when the tag is pushed
+1. Monitor the publish run in the repository's [Actions tab](https://github.com/elastic/ems-client/actions/workflows/publish.yml)
 
 ## Continuous Integration
 


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow (`.github/workflows/publish.yml`) that publishes to npm automatically when a `v*` tag is pushed
- Uses [npm Trusted Publishers](https://docs.npmjs.com/trusted-publishers) (OIDC) — no npm token secrets needed
- Publishes with `--provenance` for signed provenance attestation
- Updates `CONTRIBUTING.md` to reflect the automated release steps

## Manual setup required

Before this workflow can publish, an npm admin needs to configure the trusted publisher at https://www.npmjs.com/package/@elastic/ems-client:

1. Go to **Settings** > **Trusted Publishers**
2. Add trusted publisher:
   - **Repository owner**: `elastic`
   - **Repository name**: `ems-client`
   - **Workflow filename**: `publish.yml`
   - **Environment**: (leave blank)

## Test plan

- [ ] Configure trusted publisher on npmjs.com (see above)
- [ ] Push a test pre-release tag and verify the workflow runs
- [ ] Confirm the published package shows the provenance badge on npmjs.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)