### PR TITLE
fix(deps): update dependency lodash to ^4.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@types/geojson": "7946.0.16",
     "@types/topojson-client": "3.1.5",
     "chroma-js": "2.4.2",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.1",
     "lru-cache": "11.3.5",
     "maplibre-gl": "5.3.0",
     "semver": "7.7.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4211,7 +4211,7 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
 
-lodash@^4.17.23:
+lodash@^4.18.1:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
   integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==


### PR DESCRIPTION
## Summary
- Bumps declared `lodash` range from `^4.17.23` to `^4.18.1`
- Aligns `package.json` with the version already resolved in `yarn.lock` and with the Kibana pin
- Resolves the 🛑 mismatch reported by `.buildkite/compare_dependencies.js`

Renovate previously bumped `yarn.lock` to `4.18.1` under the existing caret range but left `package.json` at `^4.17.23`. Since `compare_dependencies.js` strips the caret and compares the floor against Kibana's pinned version, the script flagged a mismatch on every build.

## Test plan
- [x] `yarn install` regenerates lockfile cleanly
- [x] `yarn test` passes (36/36)
- [x] `node .buildkite/compare_dependencies.js` no longer reports 🛑 for `lodash`

🤖 Generated with [Claude Code](https://claude.com/claude-code)