### PR TITLE
fix(deps): update dependency lru-cache to v11.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/topojson-client": "3.1.5",
     "chroma-js": "2.4.2",
     "lodash": "^4.18.1",
-    "lru-cache": "11.3.6",
+    "lru-cache": "11.5.1",
     "maplibre-gl": "5.3.0",
     "semver": "7.8.0",
     "topojson-client": "^3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3463,10 +3463,10 @@ lru-cache@*:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.0.2.tgz#fbd8e7cf8211f5e7e5d91905c415a3f55755ca39"
   integrity sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==
 
-lru-cache@11.3.6:
-  version "11.3.6"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.3.6.tgz#f0306ad6e9f0a5dc25b16aeba4e8f57b7ec2df55"
-  integrity sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==
+lru-cache@11.5.1:
+  version "11.5.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.5.1.tgz#f3daa3540847b9737ebc02499ddb36765e54db4a"
+  integrity sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==
 
 lru-cache@^11.0.0:
   version "11.2.2"


### PR DESCRIPTION
## Summary
- update `lru-cache` from `11.3.6` to `11.5.1`
- update `yarn.lock` accordingly

## Validation
- `yarn test`
- `yarn build`
- `.buildkite/build.sh` reaches dependency comparison, but that step fails in this environment due to proxy/network access to `raw.githubusercontent.com`
