### PR TITLE
fix(ci): use BACKPORT_TOKEN (classic PAT) for backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Backport Action
         uses: sorenlouv/backport-github-action@8a6c0381851f43f9f1fddc7303f0e9015eb57b62 # v12.0.4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.BACKPORT_TOKEN }}
 
       - name: Info log
         if: ${{ success() }}


### PR DESCRIPTION
## Summary

- Replaces \`GITHUB_TOKEN\` with \`BACKPORT_TOKEN\` (classic PAT, \`repo\` scope) in the backport workflow
- \`GITHUB_TOKEN\` cannot call the \`associatedPullRequests\` GraphQL field on private repos, causing all backport runs to fail with \`[GraphQL] Resource not accessible by integration\`
- \`BACKPORT_TOKEN\` secret already exists in this repo (set 2026-08-25)
- Same fix applied and verified working in elastic/ems-server

## Test plan
- [ ] Merge a PR with a version label and verify a backport PR is created automatically